### PR TITLE
Debug tables wraps content [SKIP CI]

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -148,6 +148,6 @@ ul.trace {
 }
 
 td, th {
-	white-space: pre;
+	white-space: pre-line;
 	word-wrap: break-word;
 }


### PR DESCRIPTION
This small change is to avoid table content overflow when the text hasn't spaces to break words.
For example, this: 

![yii debugger 2013-12-18 23-09-58](https://f.cloud.github.com/assets/374554/1779724/9deca966-6854-11e3-970c-a0f840cb23c6.png)

becomes:

![yii debugger 2013-12-18 23-12-38](https://f.cloud.github.com/assets/374554/1779726/ae0c2786-6854-11e3-808e-30715a3b0f42.png)
