### PR TITLE
correct fix for display of debug toolbar on RTL pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 debug extension Change Log
 -----------------------
 
 - Enh #7655: Added ability to filter access by hostname (thiagotalma)
-- Chg: Reverted #7222 because it was messing with managing direction via CSS (samdark)
+- Bug #7222: Improved debug toolbar display in rtl pages (mohammadhosain, cebe, samdark)
 
 
 2.0.3 March 01, 2015

--- a/assets/toolbar.css
+++ b/assets/toolbar.css
@@ -13,6 +13,9 @@
     background: linear-gradient(to bottom,  rgba(237,237,237,1) 0%,rgba(246,246,246,1) 53%,rgba(255,255,255,1) 100%);
     filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ededed', endColorstr='#ffffff',GradientType=0 );
     background: rgb(246,246,246) url(data:image/svg+xml;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAoCAYAAAA/tpB3AAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB94BBQwuINct3v0AAAAjSURBVAjXY3j79u1/JgYGBgYkgpGRkYEYMSpKUGLK+/fvGQAaDAb6F86IsAAAAABJRU5ErkJggg==); /* generated using "cat assets/bg.png | base64" */
+
+    /* ensure debug toolbar text is displayed ltr even on rtl pages */
+    direction: ltr;
 }
 
 .yii-debug-toolbar-top {


### PR DESCRIPTION
fixes yiisoft/yii2#7222
see also https://github.com/yiisoft/yii2/commit/10ba054f612b00717fc51567121949aa58efe389

This change works for both cases, if `dir=rtl` is set on a HTML element and also if `direction:rtl` is set via css.