### PR TITLE
Add support for running EXPLAIN on the logged database queries

### DIFF
--- a/actions/db/ExplainAction.php
+++ b/actions/db/ExplainAction.php
@@ -1,0 +1,42 @@
+<?php
+namespace yii\debug\actions\db;
+
+use yii\base\Action;
+use yii\web\HttpException;
+
+class ExplainAction extends Action
+{
+    /**
+     * @var DebugPanel
+     */
+    public $panel;
+
+    public function run($seq, $tag)
+    {
+        $this->controller->loadData($tag);
+
+        $timings = $this->panel->calculateTimings();
+
+        if (!isset($timings[$seq])) {
+            throw new HttpException(404, 'Log message not found.');
+        }
+
+        $query = $timings[$seq]['info'];
+
+        $result = $this->panel->getDb()->createCommand('EXPLAIN ' . $query)->queryOne();
+
+        if (isset($result['id'])) {
+            unset($result['id']);
+        }
+
+        $output = [];
+        foreach ($result as $key => $value) {
+            if ($value) {
+                $output[] = sprintf('<b>%s</b>: %s', $key, $value);
+            }
+        }
+
+        return implode('<br/>', $output);
+    }
+}
+

--- a/assets/main.css
+++ b/assets/main.css
@@ -11,6 +11,33 @@ ul.trace {
     white-space: normal;
 }
 
+#db-panel-detailed-grid table tbody tr td {
+    position: relative;
+}
+
+.db-explain {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    font-size: 10px;
+}
+
+.db-explain-text {
+    display: none;
+    margin: 10px 0 0px 0;
+    font-size: 13px;
+    width: 100%;
+    word-break: break-all;
+}
+
+#db-explain-all {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    font-size: 12px;
+    margin-right: 15px;
+}
+
 ul.assets {
     margin: 2px 0 0 0;
     padding: 0;

--- a/views/default/panels/db/detail.php
+++ b/views/default/panels/db/detail.php
@@ -5,6 +5,7 @@
 
 use yii\helpers\Html;
 use yii\grid\GridView;
+use yii\web\View;
 
 ?>
 <h1><?= $panel->getName(); ?> Queries</h1>
@@ -53,7 +54,7 @@ echo GridView::widget([
         ],
         [
             'attribute' => 'query',
-            'value' => function ($data) {
+            'value' => function ($data) use ($hasExplain) {
                 $query = Html::encode($data['query']);
 
                 if (!empty($data['trace'])) {
@@ -65,6 +66,16 @@ echo GridView::widget([
                     ]);
                 }
 
+                if ($hasExplain && $data['type'] !== 'SHOW') {
+                    $query .= Html::tag('p', '', ['class' => 'db-explain-text']);
+
+                    $query .= Html::tag(
+                        'div',
+                        Html::a('[+] Explain', (['db-explain', 'seq' => $data['seq'], 'tag' => Yii::$app->controller->summary['tag']])),
+                        ['class' => 'db-explain']
+                    );
+                }
+
                 return $query;
             },
             'format' => 'html',
@@ -74,3 +85,36 @@ echo GridView::widget([
         ]
     ],
 ]);
+
+if ($hasExplain) {
+    echo Html::tag(
+        'div',
+        Html::a('[+] Explain all', '#'),
+        ['id' => 'db-explain-all']
+    );
+}
+
+$this->registerJs('debug_db_detail();', View::POS_READY);
+?>
+
+<script>
+function debug_db_detail() {
+    $('.db-explain a').click(function(e) {
+        e.preventDefault();
+        
+        var $explain = $('.db-explain-text', $(this).parent().parent());
+
+        if ($explain.is(':visible')) {
+            $explain.hide();
+        } else {
+            $explain.load($(this).attr('href')).show();
+        }
+    });
+
+    $('#db-explain-all a').click(function(e) {
+        e.preventDefault();
+        
+        $('.db-explain a').click();
+    });
+}
+</script>


### PR DESCRIPTION
As discussed earlier in yiisoft/yii2#838.

I only implemented support for mysql, sqlite, postgresql and cubrid. Oracle and MSSQL implement EXPLAINs in a non-"standard" way and I don't have any instances of those to test with. Someone else could expand on this in the future though, for example by introducing a `function explainQuery($query)` in `yii\db\Schema` and subclasses that returns the query plan data in a generic format.

![explain](https://cloud.githubusercontent.com/assets/12112486/7703767/6a204980-fe3a-11e4-973e-bbd7962b8b22.png)

