### PR TITLE
Allow specifying a default sort and filter for the DB panel

### DIFF
--- a/models/search/Db.php
+++ b/models/search/Db.php
@@ -53,24 +53,20 @@ class Db extends Base
     /**
      * Returns data provider with filled models. Filter applied if needed.
      *
-     * @param array $params an array of parameter values indexed by parameter names
      * @param array $models data to return provider for
      * @return \yii\data\ArrayDataProvider
      */
-    public function search($params, $models)
+    public function search($models)
     {
         $dataProvider = new ArrayDataProvider([
             'allModels' => $models,
             'pagination' => false,
             'sort' => [
                 'attributes' => ['duration', 'seq', 'type', 'query'],
-                'defaultOrder' => [
-                    'duration' => SORT_DESC,
-                ],
             ],
         ]);
 
-        if (!($this->load($params) && $this->validate())) {
+        if (!$this->validate()) {
             return $dataProvider;
         }
 

--- a/panels/DbPanel.php
+++ b/panels/DbPanel.php
@@ -32,6 +32,20 @@ class DbPanel extends Panel
     public $criticalQueryThreshold;
 
     /**
+     * @var array the default ordering of the database queries. In the format of
+     * [ property => sort direction ], for example: [ 'duration' => SORT_DESC ]
+     */
+    public $defaultOrder = [
+        'duration' => SORT_DESC
+    ];
+
+    /**
+     * @var array the default filter to apply to the database queries. In the format
+     * of [ property => value ], for example: [ 'type' => 'SELECT' ]
+     */
+    public $defaultFilter = [];
+
+    /**
      * @var array db queries info extracted to array as models, to use with data provider.
      */
     private $_models;
@@ -80,7 +94,13 @@ class DbPanel extends Panel
     public function getDetail()
     {
         $searchModel = new Db();
-        $dataProvider = $searchModel->search(Yii::$app->request->getQueryParams(), $this->getModels());
+
+        if (!$searchModel->load(Yii::$app->request->getQueryParams())) {
+            $searchModel->load($this->defaultFilter, '');
+        }
+
+        $dataProvider = $searchModel->search($this->getModels());
+        $dataProvider->getSort()->defaultOrder = $this->defaultOrder;
 
         return Yii::$app->view->render('panels/db/detail', [
             'panel' => $this,


### PR DESCRIPTION
Fixes #8.

Use with a config like this:

``` php
 $config['modules']['debug'] = [
    'class' => 'yii\debug\Module',
    'panels'     => [
        'db'            => [
            'class'         => 'yii\debug\panels\DbPanel',
            'defaultOrder'  => [
                'seq' => SORT_ASC
            ],
            'defaultFilter' => [
                'type' => 'SELECT'
            ]
        ],
    ],
];
```
