### PR TITLE
remove param in call to export()

### DIFF
--- a/LogTarget.php
+++ b/LogTarget.php
@@ -109,7 +109,7 @@ class LogTarget extends Target
     {
         $this->messages = array_merge($this->messages, $messages);
         if ($final) {
-            $this->export($this->messages);
+            $this->export();
         }
     }
 


### PR DESCRIPTION
`export()` does not allow any params