### PR TITLE
Added 'deeplinking' to log level type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Yii Framework 2 debug extension Change Log
 - Enh #105: Enhanced `ConfigPanel` to detect and report memcached extension presence (samdark)
 - Enh #115: Make the default panel configurable and set it to `log` (mikehaertl)
 - Enh #117: Added ability to customize the logo with `Module::setYiiLogo()` (brandonkelly)
+- Enh: The error and warning labels of the log section on the summary bar now link directly to the log page filtered by log level type
 
 2.0.6 March 17, 2016
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ Yii Framework 2 debug extension Change Log
 - Enh #105: Enhanced `ConfigPanel` to detect and report memcached extension presence (samdark)
 - Enh #115: Make the default panel configurable and set it to `log` (mikehaertl)
 - Enh #117: Added ability to customize the logo with `Module::setYiiLogo()` (brandonkelly)
-- Enh: The error and warning labels of the log section on the summary bar now link directly to the log page filtered by log level type
 
 2.0.6 March 17, 2016
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Yii Framework 2 debug extension Change Log
 - Enh #115: Make the default panel configurable and set it to `log` (mikehaertl)
 - Enh #117: Added ability to customize the logo with `Module::setYiiLogo()` (brandonkelly)
 - Enh #58: Added timeline panel (bashkarev)
+- Enh: The error and warning labels of the log section on the summary bar now link directly to the log page filtered by log level type
+
 
 2.0.6 March 17, 2016
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Yii Framework 2 debug extension Change Log
 - Enh #115: Make the default panel configurable and set it to `log` (mikehaertl)
 - Enh #117: Added ability to customize the logo with `Module::setYiiLogo()` (brandonkelly)
 - Enh #58: Added timeline panel (bashkarev)
-- Enh: The error and warning labels of the log section on the summary bar now link directly to the log page filtered by log level type
+- Enh #145: The error and warning labels of the log section on the summary bar now link directly to the log page filtered by log level type (rhertogh)
 
 
 2.0.6 March 17, 2016

--- a/Panel.php
+++ b/Panel.php
@@ -9,6 +9,7 @@ namespace yii\debug;
 
 use Yii;
 use yii\base\Component;
+use yii\helpers\ArrayHelper;
 use yii\helpers\Url;
 
 /**
@@ -96,13 +97,21 @@ class Panel extends Component
     }
 
     /**
+     * @param null|array $additionalParams Optional additional parameters to add to the route
      * @return string URL pointing to panel detail view
      */
-    public function getUrl()
+    public function getUrl($additionalParams=null)
     {
-        return Url::toRoute(['/' . $this->module->id . '/default/view',
+        $route = [
+            '/' . $this->module->id . '/default/view',
             'panel' => $this->id,
             'tag' => $this->tag,
-        ]);
+        ];
+
+        if (is_array($additionalParams)){
+            $route = ArrayHelper::merge($route, $additionalParams);
+        }
+
+        return Url::toRoute($route);
     }
 }

--- a/Panel.php
+++ b/Panel.php
@@ -100,7 +100,7 @@ class Panel extends Component
      * @param null|array $additionalParams Optional additional parameters to add to the route
      * @return string URL pointing to panel detail view
      */
-    public function getUrl($additionalParams=null)
+    public function getUrl($additionalParams = null)
     {
         $route = [
             '/' . $this->module->id . '/default/view',

--- a/views/default/panels/log/summary.php
+++ b/views/default/panels/log/summary.php
@@ -12,7 +12,7 @@ $title = 'Logged ' . count($data['messages']) . ' messages';
 $errorCount = count(Target::filterMessages($data['messages'], Logger::LEVEL_ERROR));
 $warningCount = count(Target::filterMessages($data['messages'], Logger::LEVEL_WARNING));
 
-if ($errorCount){
+if ($errorCount) {
     $title .= ", $errorCount errors";
 }
 

--- a/views/default/panels/log/summary.php
+++ b/views/default/panels/log/summary.php
@@ -11,15 +11,12 @@ use yii\log\Logger;
 $title = 'Logged ' . count($data['messages']) . ' messages';
 $errorCount = count(Target::filterMessages($data['messages'], Logger::LEVEL_ERROR));
 $warningCount = count(Target::filterMessages($data['messages'], Logger::LEVEL_WARNING));
-$output = [];
 
-if ($errorCount) {
-    $output[] = "<span class=\"yii-debug-toolbar__label yii-debug-toolbar__label_important\">$errorCount</span>";
+if ($errorCount){
     $title .= ", $errorCount errors";
 }
 
 if ($warningCount) {
-    $output[] = "<span class=\"yii-debug-toolbar__label yii-debug-toolbar__label_warning\">$warningCount</span>";
     $title .= ", $warningCount warnings";
 }
 ?>
@@ -27,6 +24,15 @@ if ($warningCount) {
 <div class="yii-debug-toolbar__block">
     <a href="<?= $panel->getUrl() ?>" title="<?= $title ?>">Log
         <span class="yii-debug-toolbar__label"><?= count($data['messages']) ?></span>
-        <?= implode('&nbsp;', $output) ?>
     </a>
+    <? if ($errorCount): ?>
+    <a href="<?= $panel->getUrl(['Log[level]' => Logger::LEVEL_ERROR])?>" title="<?= $title ?>">
+        <span class="yii-debug-toolbar__label yii-debug-toolbar__label_important"><?= $errorCount ?></span>
+    </a>
+    <? endif; ?>
+    <? if ($warningCount): ?>
+        <a href="<?= $panel->getUrl(['Log[level]' => Logger::LEVEL_WARNING])?>" title="<?= $title ?>">
+            <span class="yii-debug-toolbar__label yii-debug-toolbar__label_warning"><?= $warningCount ?></span>
+        </a>
+    <? endif; ?>
 </div>

--- a/views/default/panels/log/summary.php
+++ b/views/default/panels/log/summary.php
@@ -25,14 +25,14 @@ if ($warningCount) {
     <a href="<?= $panel->getUrl() ?>" title="<?= $title ?>">Log
         <span class="yii-debug-toolbar__label"><?= count($data['messages']) ?></span>
     </a>
-    <? if ($errorCount): ?>
+    <?php if ($errorCount): ?>
     <a href="<?= $panel->getUrl(['Log[level]' => Logger::LEVEL_ERROR])?>" title="<?= $title ?>">
         <span class="yii-debug-toolbar__label yii-debug-toolbar__label_important"><?= $errorCount ?></span>
     </a>
-    <? endif; ?>
-    <? if ($warningCount): ?>
-        <a href="<?= $panel->getUrl(['Log[level]' => Logger::LEVEL_WARNING])?>" title="<?= $title ?>">
-            <span class="yii-debug-toolbar__label yii-debug-toolbar__label_warning"><?= $warningCount ?></span>
-        </a>
-    <? endif; ?>
+    <?php endif; ?>
+    <?php if ($warningCount): ?>
+    <a href="<?= $panel->getUrl(['Log[level]' => Logger::LEVEL_WARNING])?>" title="<?= $title ?>">
+        <span class="yii-debug-toolbar__label yii-debug-toolbar__label_warning"><?= $warningCount ?></span>
+    </a>
+    <?php endif; ?>
 </div>

--- a/views/default/panels/log/summary.php
+++ b/views/default/panels/log/summary.php
@@ -12,7 +12,7 @@ $titles = ['all' => Yii::$app->i18n->format('Logged {n,plural,=1{1 message} othe
 $errorCount = count(Target::filterMessages($data['messages'], Logger::LEVEL_ERROR));
 $warningCount = count(Target::filterMessages($data['messages'], Logger::LEVEL_WARNING));
 
-if ($errorCount){
+if ($errorCount) {
     $titles['errors'] = Yii::$app->i18n->format('{n,plural,=1{1 error} other{# errors}}', ['n' => $errorCount], 'en-US');
 }
 

--- a/views/default/panels/log/summary.php
+++ b/views/default/panels/log/summary.php
@@ -8,30 +8,30 @@ use yii\log\Logger;
 ?>
 
 <?php
-$title = 'Logged ' . count($data['messages']) . ' messages';
+$titles = ['all' => Yii::$app->i18n->format('Logged {n,plural,=1{1 message} other{# messages}}', ['n' => count($data['messages'])], 'en-US')];
 $errorCount = count(Target::filterMessages($data['messages'], Logger::LEVEL_ERROR));
 $warningCount = count(Target::filterMessages($data['messages'], Logger::LEVEL_WARNING));
 
-if ($errorCount) {
-    $title .= ", $errorCount errors";
+if ($errorCount){
+    $titles['errors'] = Yii::$app->i18n->format('{n,plural,=1{1 error} other{# errors}}', ['n' => $errorCount], 'en-US');
 }
 
 if ($warningCount) {
-    $title .= ", $warningCount warnings";
+    $titles['warnings'] = Yii::$app->i18n->format('{n,plural,=1{1 warning} other{# warnings}}', ['n' => $warningCount], 'en-US');;
 }
 ?>
 
 <div class="yii-debug-toolbar__block">
-    <a href="<?= $panel->getUrl() ?>" title="<?= $title ?>">Log
+    <a href="<?= $panel->getUrl() ?>" title="<?= implode(',&nbsp;', $titles) ?>">Log
         <span class="yii-debug-toolbar__label"><?= count($data['messages']) ?></span>
     </a>
     <?php if ($errorCount): ?>
-    <a href="<?= $panel->getUrl(['Log[level]' => Logger::LEVEL_ERROR])?>" title="<?= $title ?>">
+    <a href="<?= $panel->getUrl(['Log[level]' => Logger::LEVEL_ERROR])?>" title="<?= $titles['errors'] ?>">
         <span class="yii-debug-toolbar__label yii-debug-toolbar__label_important"><?= $errorCount ?></span>
     </a>
     <?php endif; ?>
     <?php if ($warningCount): ?>
-    <a href="<?= $panel->getUrl(['Log[level]' => Logger::LEVEL_WARNING])?>" title="<?= $title ?>">
+    <a href="<?= $panel->getUrl(['Log[level]' => Logger::LEVEL_WARNING])?>" title="<?= $titles['warnings'] ?>">
         <span class="yii-debug-toolbar__label yii-debug-toolbar__label_warning"><?= $warningCount ?></span>
     </a>
     <?php endif; ?>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -

The 'error' and 'warning' counters on the summary bar 'deeplink' to their respective filters avoiding unnecessary clicks and reloads when looking for the specific log type. Example: http://prntscr.com/co7ctj