### PR TITLE
Remove heights from toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 debug extension Change Log
 - Enh: Mouse wheel click, or Ctrl+Click opens debugger in new tab (silverfire)
 - Bug #99: Avoid serializing php7 errors (zuozp8)
 - Bug #111: Fixed `LogTarget` to work properly when tests are ran via Codeception (samdark, nlmedina)
+- Bug #120: Fixed toolbar height changing when opened/closed and when using bootstrap (nkovacs)
 - Bug #93: Fixed `AssetPanel` error when bundle `$js` or `$css` contained `jsOptions` overrides (Razzwan, samdark)
 - Enh #105: Enhanced `ConfigPanel` to detect and report memcached extension presence (samdark)
 - Enh #115: Make the default panel configurable and set it to `log` (mikehaertl)

--- a/assets/toolbar.css
+++ b/assets/toolbar.css
@@ -9,14 +9,12 @@
     font: 11px Verdana, Arial, sans-serif;
     text-align: left;
     width: 96px;
-    height: 42px;
     transition: width .3s ease;
     z-index: 1000000;
 }
 
 .yii-debug-toolbar_active {
     width: 100%;
-    height: auto;
 }
 
 .yii-debug-toolbar_position_top {

--- a/assets/toolbar.css
+++ b/assets/toolbar.css
@@ -36,6 +36,7 @@
     text-align: left;
     height: 40px;
     overflow: hidden;
+    box-sizing: content-box;
 
     background: rgb(255, 255, 255);
     background: -moz-linear-gradient(top, rgb(255, 255, 255) 0%, rgb(247, 247, 247) 100%); /* FF3.6-15 */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | I hope not
| Tests pass?   | n/a
| Fixed issues  | #120 

The height when closed was 42px, the height when open was auto,
which evaluated to 40px, causing the toolbar to jump up 2 pixels
when closed.
There's no need to have a 42px height on the outer element,
since the inner element has a 40px height.
There's no need to explicitly set the height to auto either.

Fixes #120