### PR TITLE
Fix for issue #150

### DIFF
--- a/assets/toolbar.js
+++ b/assets/toolbar.js
@@ -50,7 +50,7 @@
                 div = document.createElement('div');
                 div.innerHTML = xhr.responseText;
 
-                toolbarEl.parentNode.replaceChild(div, toolbarEl);
+                toolbarEl.parentNode && toolbarEl.parentNode.replaceChild(div, toolbarEl);
 
                 showToolbar(findToolbar());
             },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #150 

Check for empty toolbarEl.parentNode before call method on it.