### PR TITLE
fix #61 to prevent undesired caching of the debug toolbar when a whol…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Yii Framework 2 debug extension Change Log
 - Enh #145: The error and warning labels of the log section on the summary bar now link directly to the log page filtered by log level type (rhertogh)
 - Bug #150: Fixed "Cannot read property 'replaceChild' of null" error (BetsuNo)
 - Enh #97: Added AJAX requests handling (bashkarev)
-
+- Bug #61: Fixed toolbar not to be cached by using renderDynamic (dynasource)
 
 2.0.6 March 17, 2016
 --------------------

--- a/Module.php
+++ b/Module.php
@@ -242,6 +242,18 @@ class Module extends \yii\base\Module implements BootstrapInterface
     }
 
     /**
+     * Gets the Toolbars html
+     * @since 2.0.7
+     */
+    public function getToolbarHtml()
+    {
+        $url = Url::toRoute(['/' . $this->id . '/default/toolbar',
+            'tag' => $this->logTarget->tag,
+        ]);
+        return '<div id="yii-debug-toolbar" data-url="' . Html::encode($url) . '" style="display:none" class="yii-debug-toolbar-bottom"></div>';
+    }
+
+    /**
      * Renders mini-toolbar at the end of page body.
      *
      * @param \yii\base\Event $event
@@ -251,12 +263,10 @@ class Module extends \yii\base\Module implements BootstrapInterface
         if (!$this->checkAccess() || Yii::$app->getRequest()->getIsAjax()) {
             return;
         }
-        $url = Url::toRoute(['/' . $this->id . '/default/toolbar',
-            'tag' => $this->logTarget->tag,
-        ]);
-        echo '<div id="yii-debug-toolbar" data-url="' . Html::encode($url) . '" style="display:none" class="yii-debug-toolbar-bottom"></div>';
+
         /* @var $view View */
         $view = $event->sender;
+        echo $view->renderDynamic('return Yii::$app->getModule("debug")->getToolbarHtml();');
 
         // echo is used in order to support cases where asset manager is not available
         echo '<style>' . $view->renderPhpFile(__DIR__ . '/assets/toolbar.css') . '</style>';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,4 +12,5 @@ require_once(__DIR__ . '/../vendor/autoload.php');
 require_once(__DIR__ . '/../vendor/yiisoft/yii2/Yii.php');
 
 Yii::setAlias('@yiiunit/extensions/debug', __DIR__);
+Yii::setAlias('@yiiunit', __DIR__ . '/../tests');
 Yii::setAlias('@yii/debug', dirname(__DIR__));


### PR DESCRIPTION
fixes #61:
- moved creation toolbar to its own method
- this method is called by renderDynamic in order for the toolbar to have its unique url loaded at all times, despite caching of the whole page
- tests are added