### PR TITLE
`yii\debug\Module::defaultVersion()` implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 debug extension Change Log
 -----------------------
 
 - Enh: Mouse wheel click, or Ctrl+Click opens debugger in new tab (silverfire)
+- Enh: `yii\debug\Module::defaultVersion()` implemented to pick up 'yiisoft/yii2-debug' extension version (klimov-paul)
 - Bug #99: Avoid serializing php7 errors (zuozp8)
 - Bug #111: Fixed `LogTarget` to work properly when tests are ran via Codeception (samdark, nlmedina)
 - Bug #120: Fixed toolbar height changing when opened/closed and when using bootstrap (nkovacs)

--- a/Module.php
+++ b/Module.php
@@ -10,6 +10,7 @@ namespace yii\debug;
 use Yii;
 use yii\base\Application;
 use yii\base\BootstrapInterface;
+use yii\helpers\Json;
 use yii\web\Response;
 use yii\helpers\Html;
 use yii\helpers\Url;
@@ -310,5 +311,19 @@ class Module extends \yii\base\Module implements BootstrapInterface
             'mail' => ['class' => 'yii\debug\panels\MailPanel'],
             'timeline' => ['class' => 'yii\debug\panels\TimelinePanel']
         ];
+    }
+
+    /**
+     * @inheritdoc
+     * @since 2.0.7
+     */
+    protected function defaultVersion()
+    {
+        $packageInfo = Json::decode(file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . 'composer.json'));
+        $extensionName = $packageInfo['name'];
+        if (isset(Yii::$app->extensions[$extensionName])) {
+            return Yii::$app->extensions[$extensionName]['version'];
+        }
+        return parent::defaultVersion();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
             "email": "qiang.xue@gmail.com"
         }
     ],
+    "minimum-stability": "dev",
     "require": {
         "yiisoft/yii2": "~2.0.4",
         "yiisoft/yii2-bootstrap": "~2.0.0"

--- a/tests/ModuleTest.php
+++ b/tests/ModuleTest.php
@@ -108,4 +108,16 @@ HTML
         }
         $this->assertNotEquals($output[0],$output[1]);
     }
+
+    public function testDefaultVersion()
+    {
+        Yii::$app->extensions['yiisoft/yii2-debug'] = [
+            'name' => 'yiisoft/yii2-debug',
+            'version' => '2.0.7',
+        ];
+
+        $module = new Module('debug');
+
+        $this->assertEquals('2.0.7', $module->getVersion());
+    }
 } 


### PR DESCRIPTION
Extracted from https://github.com/yiisoft/yii2/issues/12726

`yii\debug\Module::defaultVersion()` implemented to pick up 'yiisoft/yii2-debug' extension version

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes