### PR TITLE
Refactoring container blocks in order to introduce ID

### DIFF
--- a/Panel.php
+++ b/Panel.php
@@ -15,12 +15,10 @@ use yii\helpers\Url;
 /**
  * Panel is a base class for debugger panel classes. It defines how data should be collected,
  * what should be displayed at debug toolbar and on debugger details view.
- *
  * @property string $detail Content that is displayed in debugger detail view. This property is read-only.
  * @property string $name Name of the panel. This property is read-only.
  * @property string $summary Content that is displayed at debug toolbar. This property is read-only.
  * @property string $url URL pointing to panel detail view. This property is read-only.
- *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
  */
@@ -68,6 +66,14 @@ class Panel extends Component
     }
 
     /**
+     * @return bool if the panel has a summary
+     */
+    public function hasSummary()
+    {
+        return true;
+    }
+
+    /**
      * @return string content that is displayed in debugger detail view
      */
     public function getDetail()
@@ -78,7 +84,6 @@ class Panel extends Component
     /**
      * Saves data to be later used in debugger detail view.
      * This method is called on every page where debugger is enabled.
-     *
      * @return mixed data to be saved
      */
     public function save()
@@ -88,7 +93,6 @@ class Panel extends Component
 
     /**
      * Loads data into the panel
-     *
      * @param mixed $data
      */
     public function load($data)
@@ -108,7 +112,7 @@ class Panel extends Component
             'tag' => $this->tag,
         ];
 
-        if (is_array($additionalParams)){
+        if (is_array($additionalParams)) {
             $route = ArrayHelper::merge($route, $additionalParams);
         }
 

--- a/panels/AssetPanel.php
+++ b/panels/AssetPanel.php
@@ -40,6 +40,14 @@ class AssetPanel extends Panel
     /**
      * @inheritdoc
      */
+    public function hasSummary()
+    {
+        return !empty($this->data);
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function getDetail()
     {
         return Yii::$app->view->render('panels/assets/detail', ['panel' => $this]);

--- a/panels/DbPanel.php
+++ b/panels/DbPanel.php
@@ -92,6 +92,16 @@ class DbPanel extends Panel
     /**
      * @inheritdoc
      */
+    public function hasSummary()
+    {
+        $timings = $this->calculateTimings();
+        $queryCount = count($timings);
+        return $queryCount > 0;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function getDetail()
     {
         $searchModel = new Db();

--- a/panels/MailPanel.php
+++ b/panels/MailPanel.php
@@ -114,7 +114,7 @@ class MailPanel extends Panel
      */
     public function hasSummary()
     {
-        return count($this->data);
+        return count($this->data) > 0;
     }
 
     /**

--- a/panels/MailPanel.php
+++ b/panels/MailPanel.php
@@ -112,6 +112,14 @@ class MailPanel extends Panel
     /**
      * @inheritdoc
      */
+    public function hasSummary()
+    {
+        return count($this->data);
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function getDetail()
     {
         $searchModel = new Mail();

--- a/tests/PanelTest.php
+++ b/tests/PanelTest.php
@@ -8,6 +8,24 @@ use yii\debug\Panel;
 
 class PanelTest extends TestCase
 {
+    public function testGetName()
+    {
+        $panel = $this->getPanel();
+        $this->assertEquals('', $panel->getName());
+    }
+
+    public function testGetSummary()
+    {
+        $panel = $this->getPanel();
+        $this->assertEquals('', $panel->getSummary());
+    }
+
+    public function testHasSummary()
+    {
+        $panel = $this->getPanel();
+        $this->assertTrue($panel->hasSummary());
+    }
+
     public function testGetTraceLine_DefaultLink()
     {
         $traceConfig = [

--- a/views/default/panels/assets/summary.php
+++ b/views/default/panels/assets/summary.php
@@ -1,8 +1,6 @@
 <?php
 /* @var $panel yii\debug\panels\AssetPanel */
-if (!empty($panel->data)):
 ?>
-<div class="yii-debug-toolbar__block">
-    <a href="<?= $panel->getUrl() ?>" title="Number of asset bundles loaded">Asset Bundles <span class="yii-debug-toolbar__label yii-debug-toolbar__label_info"><?= count($panel->data) ?></span></a>
-</div>
-<?php endif; ?>
+<a href="<?= $panel->getUrl() ?>" title="Number of asset bundles loaded">Asset Bundles <span class="yii-debug-toolbar__label yii-debug-toolbar__label_info"><?= count($panel->data) ?></span></a>
+
+

--- a/views/default/panels/config/summary.php
+++ b/views/default/panels/config/summary.php
@@ -1,10 +1,8 @@
 <?php
 /* @var $panel yii\debug\panels\ConfigPanel */
 ?>
-<div class="yii-debug-toolbar__block">
-    <a href="<?= $panel->getUrl() ?>">
-        <span class="yii-debug-toolbar__label"><?= $panel->data['application']['yii'] ?></span>
-        PHP
-        <span class="yii-debug-toolbar__label"><?= $panel->data['php']['version'] ?></span>
-    </a>
-</div>
+<a href="<?= $panel->getUrl() ?>">
+    <span class="yii-debug-toolbar__label"><?= $panel->data['application']['yii'] ?></span>
+    PHP
+    <span class="yii-debug-toolbar__label"><?= $panel->data['php']['version'] ?></span>
+</a>

--- a/views/default/panels/db/detail.php
+++ b/views/default/panels/db/detail.php
@@ -3,8 +3,8 @@
 /* @var $searchModel yii\debug\models\search\Db */
 /* @var $dataProvider yii\data\ArrayDataProvider */
 
-use yii\helpers\Html;
 use yii\grid\GridView;
+use yii\helpers\Html;
 use yii\web\View;
 
 echo Html::tag('h1', $panel->getName() . ' Queries');
@@ -22,7 +22,7 @@ echo GridView::widget([
             'label' => 'Time',
             'value' => function ($data) {
                 $timeInSeconds = $data['timestamp'] / 1000;
-                $millisecondsDiff = (int) (($timeInSeconds - (int) $timeInSeconds) * 1000);
+                $millisecondsDiff = (int)(($timeInSeconds - (int)$timeInSeconds) * 1000);
 
                 return date('H:i:s.', $timeInSeconds) . sprintf('%03d', $millisecondsDiff);
             },
@@ -95,25 +95,25 @@ $this->registerJs('debug_db_detail();', View::POS_READY);
 ?>
 
 <script>
-function debug_db_detail() {
-    $('.db-explain a').on('click', function(e) {
-        e.preventDefault();
-        
-        var $explain = $('.db-explain-text', $(this).parent().parent());
+    function debug_db_detail() {
+        $('.db-explain a').on('click', function (e) {
+            e.preventDefault();
 
-        if ($explain.is(':visible')) {
-            $explain.hide();
-            $(this).text('[+] Explain');
-        } else {
-            $explain.load($(this).attr('href')).show();
-            $(this).text('[-] Explain');
-        }
-    });
+            var $explain = $('.db-explain-text', $(this).parent().parent());
 
-    $('#db-explain-all a').on('click', function(e) {
-        e.preventDefault();
-        
-        $('.db-explain a').click();
-    });
-}
+            if ($explain.is(':visible')) {
+                $explain.hide();
+                $(this).text('[+] Explain');
+            } else {
+                $explain.load($(this).attr('href')).show();
+                $(this).text('[-] Explain');
+            }
+        });
+
+        $('#db-explain-all a').on('click', function (e) {
+            e.preventDefault();
+
+            $('.db-explain a').click();
+        });
+    }
 </script>

--- a/views/default/panels/db/summary.php
+++ b/views/default/panels/db/summary.php
@@ -3,10 +3,6 @@
 /* @var $queryCount integer */
 /* @var $queryTime integer */
 ?>
-<?php if ($queryCount): ?>
-<div class="yii-debug-toolbar__block">
-    <a href="<?= $panel->getUrl() ?>" title="Executed <?= $queryCount ?> database queries which took <?= $queryTime ?>.">
-        <?= $panel->getSummaryName() ?> <span class="yii-debug-toolbar__label yii-debug-toolbar__label_info"><?= $queryCount ?></span> <span class="yii-debug-toolbar__label"><?= $queryTime ?></span>
-    </a>
-</div>
-<?php endif; ?>
+<a href="<?= $panel->getUrl() ?>" title="Executed <?= $queryCount ?> database queries which took <?= $queryTime ?>.">
+    <?= $panel->getSummaryName() ?> <span class="yii-debug-toolbar__label yii-debug-toolbar__label_info"><?= $queryCount ?></span> <span class="yii-debug-toolbar__label"><?= $queryTime ?></span>
+</a>

--- a/views/default/panels/log/summary.php
+++ b/views/default/panels/log/summary.php
@@ -21,18 +21,18 @@ if ($warningCount) {
 }
 ?>
 
-<div class="yii-debug-toolbar__block">
-    <a href="<?= $panel->getUrl() ?>" title="<?= implode(',&nbsp;', $titles) ?>">Log
-        <span class="yii-debug-toolbar__label"><?= count($data['messages']) ?></span>
-    </a>
-    <?php if ($errorCount): ?>
-    <a href="<?= $panel->getUrl(['Log[level]' => Logger::LEVEL_ERROR])?>" title="<?= $titles['errors'] ?>">
-        <span class="yii-debug-toolbar__label yii-debug-toolbar__label_important"><?= $errorCount ?></span>
-    </a>
-    <?php endif; ?>
-    <?php if ($warningCount): ?>
-    <a href="<?= $panel->getUrl(['Log[level]' => Logger::LEVEL_WARNING])?>" title="<?= $titles['warnings'] ?>">
-        <span class="yii-debug-toolbar__label yii-debug-toolbar__label_warning"><?= $warningCount ?></span>
-    </a>
-    <?php endif; ?>
-</div>
+
+<a href="<?= $panel->getUrl() ?>" title="<?= implode(',&nbsp;', $titles) ?>">Log
+    <span class="yii-debug-toolbar__label"><?= count($data['messages']) ?></span>
+</a>
+<?php if ($errorCount): ?>
+<a href="<?= $panel->getUrl(['Log[level]' => Logger::LEVEL_ERROR])?>" title="<?= $titles['errors'] ?>">
+    <span class="yii-debug-toolbar__label yii-debug-toolbar__label_important"><?= $errorCount ?></span>
+</a>
+<?php endif; ?>
+<?php if ($warningCount): ?>
+<a href="<?= $panel->getUrl(['Log[level]' => Logger::LEVEL_WARNING])?>" title="<?= $titles['warnings'] ?>">
+    <span class="yii-debug-toolbar__label yii-debug-toolbar__label_warning"><?= $warningCount ?></span>
+</a>
+<?php endif; ?>
+

--- a/views/default/panels/mail/summary.php
+++ b/views/default/panels/mail/summary.php
@@ -1,8 +1,9 @@
 <?php
 /* @var $panel yii\debug\panels\MailPanel */
 /* @var $mailCount integer */
-if ($mailCount): ?>
-<div class="yii-debug-toolbar__block">
-    <a href="<?= $panel->getUrl() ?>">Mail <span class="yii-debug-toolbar__label"><?= $mailCount ?></span></a>
-</div>
-<?php endif ?>
+?>
+<a href="<?= $panel->getUrl() ?>">
+    Mail
+    <span class="yii-debug-toolbar__label">
+    <?= $mailCount ?></span>
+</a>

--- a/views/default/panels/profile/summary.php
+++ b/views/default/panels/profile/summary.php
@@ -3,7 +3,6 @@
 /* @var $time integer */
 /* @var $memory integer */
 ?>
-<div class="yii-debug-toolbar__block">
-    <a href="<?= $panel->getUrl() ?>" title="Total request processing time was <?= $time ?>">Time <span class="yii-debug-toolbar__label yii-debug-toolbar__label_info"><?= $time ?></span></a>
-    <a href="<?= $panel->getUrl() ?>" title="Peak memory consumption">Memory <span class="yii-debug-toolbar__label yii-debug-toolbar__label_info"><?= $memory ?></span></a>
-</div>
+
+<a href="<?= $panel->getUrl() ?>" title="Total request processing time was <?= $time ?>">Time <span class="yii-debug-toolbar__label yii-debug-toolbar__label_info"><?= $time ?></span></a>
+<a href="<?= $panel->getUrl() ?>" title="Peak memory consumption">Memory <span class="yii-debug-toolbar__label yii-debug-toolbar__label_info"><?= $memory ?></span></a>

--- a/views/default/panels/request/summary.php
+++ b/views/default/panels/request/summary.php
@@ -17,7 +17,6 @@ if ($statusCode >= 200 && $statusCode < 300) {
 }
 $statusText = Html::encode(isset(Response::$httpStatuses[$statusCode]) ? Response::$httpStatuses[$statusCode] : '');
 ?>
-<div class="yii-debug-toolbar__block">
-    <a href="<?= $panel->getUrl() ?>" title="Status code: <?= $statusCode ?> <?= $statusText ?>">Status <span class="yii-debug-toolbar__label <?= $class ?>"><?= $statusCode ?></span></a>
-    <a href="<?= $panel->getUrl() ?>" title="Action: <?= $panel->data['action'] ?>">Route <span class="yii-debug-toolbar__label"><?= $panel->data['route'] ?></span></a>
-</div>
+
+<a href="<?= $panel->getUrl() ?>" title="Status code: <?= $statusCode ?> <?= $statusText ?>">Status <span class="yii-debug-toolbar__label <?= $class ?>"><?= $statusCode ?></span></a>
+<a href="<?= $panel->getUrl() ?>" title="Action: <?= $panel->data['action'] ?>">Route <span class="yii-debug-toolbar__label"><?= $panel->data['route'] ?></span></a>

--- a/views/default/toolbar.php
+++ b/views/default/toolbar.php
@@ -36,9 +36,19 @@ $url = $firstPanel->getUrl();
             </div>
         </div>
 
-        <?php foreach ($panels as $panel): ?>
-            <?= $panel->getSummary() ?>
-        <?php endforeach; ?>
+        <?php foreach ($panels as $panel){
+            if (!$panel->hasSummary()) {
+                continue;
+            }
+            $summary = $panel->getSummary();
+            if ($summary === '') {
+                continue;
+            }
+        ?>
+        <div class="yii-debug-toolbar__block" id="<?= $panel->getName() ?>">
+            <?= $summary; ?>
+        </div>
+        <?php }?>
 
         <div class="yii-debug-toolbar__block_last">
 


### PR DESCRIPTION
In order to fix https://github.com/yiisoft/yii2-debug/issues/164 I stumbled on several issues with the current panel views:
* all these panels have views creating the same containers. This is error prone as the JS depends on the panels to have the right DIV containers
* its not DRY
* logic should not be in the view files (logic about whether to publish a summary)
* IDs to these containers cannot easily be added (to fix https://github.com/yiisoft/yii2-debug/issues/164)

This PR contains the fixes:
- centralized creation of summary container blocks
- centralized checking for rendering of summary container blocks
 - introduced new method to do this check: hasSummary
- added ID to container block
- added basic tests