### PR TITLE
toogle button direction fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.0.7 under development
 -----------------------
 
+- Bug #168: Fixed wrong toggle button direction (fps01)
 - Enh: Mouse wheel click, or Ctrl+Click opens debugger in new tab (silverfire)
 - Enh: `yii\debug\Module::defaultVersion()` implemented to pick up 'yiisoft/yii2-debug' extension version (klimov-paul)
 - Bug #99: Avoid serializing php7 errors (zuozp8)

--- a/assets/toolbar.css
+++ b/assets/toolbar.css
@@ -247,11 +247,13 @@ a.yii-debug-toolbar__label:focus {
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNSIgaGVpZ2h0PSIxNSIgdmlld0JveD0iMCAwIDUwIDUwIj48cGF0aCBmaWxsPSIjNDQ0IiBkPSJNMTUuNTYzIDQwLjgzNmEuOTk3Ljk5NyAwIDAgMCAxLjQxNCAwbDE1LTE1YTEgMSAwIDAgMCAwLTEuNDE0bC0xNS0xNWExIDEgMCAwIDAtMS40MTQgMS40MTRMMjkuODU2IDI1LjEzIDE1LjU2MyAzOS40MmExIDEgMCAwIDAgMCAxLjQxNHoiLz48L3N2Zz4=');
     transition: -webkit-transform .3s ease-out;
     transition: transform .3s ease-out;
+    -webkit-transform: rotate(180deg);
+    transform: rotate(180deg);
 }
 
 .yii-debug-toolbar_active .yii-debug-toolbar__toggle-icon {
-    -webkit-transform: rotate(180deg);
-    transform: rotate(180deg);
+    -webkit-transform: rotate(0);
+    transform: rotate(0);
 }
 
 .yii-debug-toolbar_iframe_active .yii-debug-toolbar__toggle-icon {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

- When iframe is opened the toggle arrow is directed down. It shows a direction of panel moving.
- When the debug panel is collapsed the toggle arrow is directed right and when the panel is opened the toggle arrow is directed left. It shows a wrong direction of panel moving.