### PR TITLE
Timeline, memory graph

### DIFF
--- a/assets/timeline.css
+++ b/assets/timeline.css
@@ -43,7 +43,7 @@
   cursor: pointer;
 }
 .debug-timeline-panel .category span {
-  color: #7d7d7d;;
+  color: #7d7d7d;
 }
 .debug-timeline-panel .right > .category {
   right: 100%;
@@ -178,30 +178,23 @@
 }
 .debug-timeline-panel__memory{
   position: relative;
-  height: 28px;
+  height: 40px;
+  margin-top: 16px;
   border-bottom: 1px solid #ddd;
 }
 .debug-timeline-panel__memory .range attr {
   font-size: 10px;
   line-height: 10px;
   position: absolute;
+  border-bottom: 1px dashed #ddd;
+  width: 100%;
+  z-index: 4;
 }
-.debug-timeline-panel__memory .range .min {
-  bottom: -4px;
-  left: -25px;
-}
-.debug-timeline-panel__memory .range .min:before {
-  content: '';
-  height: 1px;
-  width: 4px;
-  background-color: #ddd;
+.debug-timeline-panel__memory .range attr span{
   position: absolute;
-  bottom: 3px;
-  right: -5px;
-}
-.debug-timeline-panel__memory .range .max {
-  top: -10px;
-  right: 0px;
+  margin-top: -5px;
+  padding: 0 3px 0 6px;
+  background-color: #fff;
 }
 
 

--- a/assets/timeline.css
+++ b/assets/timeline.css
@@ -45,6 +45,10 @@
 .debug-timeline-panel .category span {
   color: #7d7d7d;
 }
+.debug-timeline-panel .category span.memory[title] {
+  cursor: help;
+  border-bottom: 1px dotted #777;
+}
 .debug-timeline-panel .right > .category {
   right: 100%;
 }
@@ -176,25 +180,23 @@
 .debug-timeline-panel__search input#timeline-category {
   min-width: 185px;
 }
-.debug-timeline-panel__memory{
+.debug-timeline-panel__memory {
   position: relative;
-  height: 40px;
-  margin-top: 16px;
+  margin-top: 18px;
+  box-sizing: content-box;
   border-bottom: 1px solid #ddd;
 }
-.debug-timeline-panel__memory .range attr {
-  font-size: 10px;
-  line-height: 10px;
-  position: absolute;
-  border-bottom: 1px dashed #ddd;
+.debug-timeline-panel__memory svg{
   width: 100%;
-  z-index: 4;
 }
-.debug-timeline-panel__memory .range attr span{
+.debug-timeline-panel__memory .scale {
+  font-size: 12px;
+  line-height: 16px;
   position: absolute;
-  margin-top: -5px;
-  padding: 0 3px 0 6px;
-  background-color: #fff;
+  border-bottom: 1px dashed #000;
+  width: 100%;
+  padding-left: 6px;
+  transition: bottom 0.2s ease;
 }
 
 

--- a/assets/timeline.css
+++ b/assets/timeline.css
@@ -176,6 +176,35 @@
 .debug-timeline-panel__search input#timeline-category {
   min-width: 185px;
 }
+.debug-timeline-panel__memory{
+  position: relative;
+  height: 28px;
+  border-bottom: 1px solid #ddd;
+}
+.debug-timeline-panel__memory .range attr {
+  font-size: 10px;
+  line-height: 10px;
+  position: absolute;
+}
+.debug-timeline-panel__memory .range .min {
+  bottom: -4px;
+  left: -25px;
+}
+.debug-timeline-panel__memory .range .min:before {
+  content: '';
+  height: 1px;
+  width: 4px;
+  background-color: #ddd;
+  position: absolute;
+  bottom: 3px;
+  right: -5px;
+}
+.debug-timeline-panel__memory .range .max {
+  top: -10px;
+  right: 0px;
+}
+
+
 @media (max-width:767px) {
   .debug-timeline-panel .ruler:nth-child(2n) b{
     display: none;

--- a/assets/timeline.js
+++ b/assets/timeline.js
@@ -10,7 +10,14 @@
                 this.options.$focus.focus();
                 delete this.options.$focus;
             }
-            self.options.$timeline.find('.debug-timeline-panel__item a').tooltip();
+            self.options.$timeline.find('.debug-timeline-panel__item a')
+                .on('show.bs.tooltip', function () {
+                    var data = $(this).data('memory');
+                    if (data) {
+                        self.options.$memory.text(data[0]).css({'bottom': data[1]+'%'});
+                    }
+                })
+                .tooltip();
             return self;
         };
         this.setFocus = function ($elem) {
@@ -53,6 +60,7 @@
     (new Timeline({
         '$timeline': $('.debug-timeline-panel'),
         '$header': $('.debug-timeline-panel__header'),
-        '$search': $('.debug-timeline-panel__search input')
+        '$search': $('.debug-timeline-panel__search input'),
+        '$memory': $('.debug-timeline-panel__memory .scale')
     }));
 })();

--- a/models/timeline/DataProvider.php
+++ b/models/timeline/DataProvider.php
@@ -145,4 +145,24 @@ class DataProvider extends ArrayDataProvider
         return $data;
     }
 
+    /**
+     * ```php
+     * [
+     *   0 => string, memory usage (MB)
+     *   1 => float, Y position (percent)
+     * ]
+     * @param array $model
+     * @return array|null
+     */
+    public function getMemory($model)
+    {
+        if (empty($model['memory'])) {
+            return null;
+        }
+        return [
+            sprintf('%.2f MB', $model['memory'] / 1048576),
+            $model['memory'] / ($this->panel->memory / 100)
+        ];
+    }
+
 }

--- a/models/timeline/DataProvider.php
+++ b/models/timeline/DataProvider.php
@@ -5,20 +5,21 @@
  * @license http://www.yiiframework.com/license/
  */
 
-namespace yii\debug\components;
+namespace yii\debug\models\timeline;
 
 use yii\data\ArrayDataProvider;
 use yii\debug\panels\TimelinePanel;
+use yii\helpers\VarDumper;
 
 /**
- * TimelineDataProvider implements a data provider based on a data array.
+ * DataProvider implements a data provider based on a data array.
  *
  * @property array $rulers This property is read-only.
  *
  * @author Dmitriy Bashkarev <dmitriy@bashkarev.com>
- * @since 2.0.7
+ * @since 2.0.8
  */
-class TimelineDataProvider extends ArrayDataProvider
+class DataProvider extends ArrayDataProvider
 {
     /**
      * @var TimelinePanel
@@ -27,7 +28,7 @@ class TimelineDataProvider extends ArrayDataProvider
 
 
     /**
-     * TimelineDataProvider constructor.
+     * DataProvider constructor.
      * @param TimelinePanel $panel
      * @param array $config
      */

--- a/models/timeline/DataProvider.php
+++ b/models/timeline/DataProvider.php
@@ -9,7 +9,6 @@ namespace yii\debug\models\timeline;
 
 use yii\data\ArrayDataProvider;
 use yii\debug\panels\TimelinePanel;
-use yii\helpers\VarDumper;
 
 /**
  * DataProvider implements a data provider based on a data array.

--- a/models/timeline/Search.php
+++ b/models/timeline/Search.php
@@ -5,20 +5,20 @@
  * @license http://www.yiiframework.com/license/
  */
 
-namespace yii\debug\models\search;
+namespace yii\debug\models\timeline;
 
 use yii\debug\components\search\Filter;
 use yii\debug\components\search\matchers\GreaterThanOrEqual;
-use yii\debug\components\TimelineDataProvider;
+use yii\debug\models\search\Base;
 use yii\debug\panels\TimelinePanel;
 
 /**
  * Search model for timeline data.
  *
  * @author Dmitriy Bashkarev <dmitriy@bashkarev.com>
- * @since 2.0.7
+ * @since 2.0.8
  */
-class Timeline extends Base
+class Search extends Base
 {
     /**
      * @var string attribute search
@@ -55,12 +55,12 @@ class Timeline extends Base
      *
      * @param array $params $params an array of parameter values indexed by parameter names
      * @param TimeLinePanel $panel
-     * @return TimelineDataProvider
+     * @return DataProvider
      */
     public function search($params, $panel)
     {
         $models = $panel->models;
-        $dataProvider = new TimelineDataProvider($panel, [
+        $dataProvider = new DataProvider($panel, [
             'allModels' => $models,
             'sort' => [
                 'attributes' => ['category', 'timestamp']

--- a/models/timeline/Svg.php
+++ b/models/timeline/Svg.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\debug\models\timeline;
+
+use yii\base\Model;
+use yii\debug\panels\TimelinePanel;
+
+/**
+ * @author Dmitriy Bashkarev <dmitriy@bashkarev.com>
+ * @since 2.0.8
+ */
+class Svg extends Model
+{
+    /**
+     * @var int Max coordinate
+     */
+    public $x = 100;
+    /**
+     * @var int Max coordinate
+     */
+    public $y = 28;
+    /**
+     * @var array
+     */
+    public $listenMessages = ['log', 'profiling'];
+    /**
+     * @var string
+     */
+    public $template = '<svg width="{x}%" height="{y}" viewBox="0 0 {x} {y}" preserveAspectRatio="none">
+            <defs>
+                <linearGradient id="gradient" x1="0" x2="0" y1="1" y2="0">
+                    <stop offset="10%" stop-color="#d6e685"></stop>
+                    <stop offset="33%" stop-color="#8cc665"></stop>
+                    <stop offset="66%" stop-color="#44a340"></stop>
+                    <stop offset="90%" stop-color="#1e6823"></stop>
+                </linearGradient>
+                <mask id="sparkline" x="0" y="0" width="{x}%" height="{y}">
+                    <polyline transform="translate(0, {y}) scale(1,-1)" points="{points}" fill="transparent" stroke="#8cc665" stroke-width="2"/>
+                </mask>
+            </defs>
+            <g transform="translate(0, 2.0)">
+                <rect x="0" y="0" width="{x}%" height="{y}" style="stroke: none; fill: url(#gradient); mask: url(#sparkline)"></rect>
+            </g>
+        </svg>';
+    /**
+     * [
+     *  [x, y]
+     * ]
+     * @var \SplMinHeap
+     */
+    protected $points;
+    /**
+     * @var TimelinePanel
+     */
+    protected $panel;
+
+
+    /**
+     * @inheritdoc
+     */
+    public function __construct(TimelinePanel $panel, $config = [])
+    {
+        $this->panel = $panel;
+        $this->points = new \SplMinHeap();
+        parent::__construct($config);
+        foreach ($this->listenMessages as $panel) {
+            if (isset($this->panel->module->panels[$panel]->data['messages'])) {
+                $this->addPoints($this->panel->module->panels[$panel]->data['messages']);
+            }
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        if ($this->points->count() === 0) {
+            return '';
+        }
+
+        return strtr($this->template, [
+            '{x}' => $this->x,
+            '{y}' => $this->y,
+            '{points}' => $this->getPoints()
+        ]);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPoints()
+    {
+        $str = '';
+        foreach ($this->points as $point) {
+            $str .= ' ' . $point[0] . ',' . $point[1];
+        }
+        if ($str === '') {
+            return null;
+        }
+        return "0,0{$str} 100,{$point[1]}";
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasPoints()
+    {
+        return ($this->points->count() !== 0);
+    }
+
+    /**
+     * @param $messages
+     */
+    protected function addPoints($messages)
+    {
+        $yOne = $this->panel->memory / 100; // - 1 percent |rename
+        $yMax = $this->y / 100; // 1 percent coordinate |rename
+
+        $xOne = $this->panel->duration / $this->x;
+
+        foreach ($messages as $message) {
+            if (!isset($message[5])) {
+                break;
+            }
+            $x = ($message[3] * 1000 - $this->panel->start) / $xOne;
+            $y = $message[5] / $yOne * $yMax;
+            $this->points->insert([$x, $y]);
+        }
+    }
+
+}

--- a/models/timeline/Svg.php
+++ b/models/timeline/Svg.php
@@ -32,20 +32,7 @@ class Svg extends Model
      * @var string
      */
     public $template = '<svg width="{x}%" height="{y}" viewBox="0 0 {x} {y}" preserveAspectRatio="none">
-            <defs>
-                <linearGradient id="gradient" x1="0" x2="0" y1="1" y2="0">
-                    <stop offset="10%" stop-color="#d6e685"></stop>
-                    <stop offset="33%" stop-color="#8cc665"></stop>
-                    <stop offset="66%" stop-color="#44a340"></stop>
-                    <stop offset="90%" stop-color="#1e6823"></stop>
-                </linearGradient>
-                <mask id="sparkline" x="0" y="0" width="{x}%" height="{y}">
-                    <polyline transform="translate(0, {y}) scale(1,-1)" points="{points}" fill="transparent" stroke="#8cc665" stroke-width="2"/>
-                </mask>
-            </defs>
-            <g transform="translate(0, 2.0)">
-                <rect x="0" y="0" width="{x}%" height="{y}" style="stroke: none; fill: url(#gradient); mask: url(#sparkline)"></rect>
-            </g>
+            <path  x="0" y="0" transform="scale(1 1)" d="{points}" fill="#9DE281" stroke-width="1" stroke="#FDD000"  />
         </svg>';
     /**
      * [
@@ -87,7 +74,8 @@ class Svg extends Model
         return strtr($this->template, [
             '{x}' => $this->x,
             '{y}' => $this->y,
-            '{points}' => $this->getPoints()
+            '{points}' => $this->getPoints(),
+            '{linearGradient}' => $this->linearGradient()
         ]);
     }
 
@@ -98,12 +86,24 @@ class Svg extends Model
     {
         $str = '';
         foreach ($this->points as $point) {
-            $str .= ' ' . $point[0] . ',' . $point[1];
+            $str .= ' L ' . $point[0] . ',' . $point[1];
         }
         if ($str === '') {
             return null;
         }
-        return "0,0{$str} 100,{$point[1]}";
+        return "M 0,0{$str} L 100,{$point[1]} z";
+    }
+
+    /**
+     * @return string
+     */
+    protected function linearGradient()
+    {
+        $gradient = '<linearGradient id="gradient" x1="0" x2="0" y1="1" y2="0">';
+        foreach ($this->panel->getGradient() as $percent => $color) {
+            $gradient .='<stop offset="'.$percent.'%" stop-color="'.$color.'"></stop>';
+        }
+        return $gradient.'</linearGradient>';
     }
 
     /**

--- a/panels/TimelinePanel.php
+++ b/panels/TimelinePanel.php
@@ -39,13 +39,6 @@ class TimelinePanel extends Panel
         1 => '#8cc665'
     ];
     /**
-     * @var array Color indicators svg graph.
-     */
-    private $_gradient = [
-        10 => '#FAD961',
-        90 => '#F76B1C'
-    ];
-    /**
      * @var array log messages extracted to array as models, to use with data provider.
      */
     private $_models;
@@ -65,6 +58,12 @@ class TimelinePanel extends Panel
      * @var Svg|null
      */
     private $_svg;
+    /**
+     * @var array
+     */
+    private $_svgOptions = [
+        'class' => 'yii\debug\models\timeline\Svg'
+    ];
     /**
      * @var int Used memory in request
      */
@@ -170,24 +169,22 @@ class TimelinePanel extends Panel
     }
 
     /**
-     * Sets color indicators svg graph,
-     * key: percentages of memory used, value: hex color
-     * @param array $colors
+     * @param array $options
      */
-    public function setGradient($colors)
+    public function setSvgOptions($options)
     {
-        asort($colors);
-        $this->_gradient = $colors;
+        if ($this->_svg !== null) {
+            $this->_svg = null;
+        }
+        $this->_svgOptions = array_merge($this->_svgOptions, $options);
     }
 
     /**
-     * Color indicators svg graph,
-     * key: percentages of memory used, value: hex color
      * @return array
      */
-    public function getGradient()
+    public function getSvgOptions()
     {
-        return $this->_gradient;
+        return $this->_svgOptions;
     }
 
     /**
@@ -225,7 +222,7 @@ class TimelinePanel extends Panel
     public function getSvg()
     {
         if ($this->_svg === null) {
-            $this->_svg = new Svg($this);
+            $this->_svg = Yii::createObject($this->_svgOptions,[$this]);
         }
         return $this->_svg;
     }

--- a/panels/TimelinePanel.php
+++ b/panels/TimelinePanel.php
@@ -206,7 +206,7 @@ class TimelinePanel extends Panel
     }
 
     /**
-     * Memory peak in request, bytes. (obtained by memory_get_peak_usage(true))
+     * Memory peak in request, bytes. (obtained by memory_get_peak_usage())
      * @return int
      * @since 2.0.8
      */

--- a/panels/TimelinePanel.php
+++ b/panels/TimelinePanel.php
@@ -19,7 +19,7 @@ use yii\base\InvalidConfigException;
  * @property array $colors color indicators
  * @property float $duration request duration, milliseconds. This property is read-only.
  * @property float $start timestamp of starting request. This property is read-only.
- * @property int $memory Used memory in request. This property is read-only.
+ * @property int $memory Memory peak in request. This property is read-only.
  * @property Svg $svg. This property is read-only.
  *
  * @author Dmitriy Bashkarev <dmitriy@bashkarev.com>
@@ -42,10 +42,8 @@ class TimelinePanel extends Panel
      * @var array Color indicators svg graph.
      */
     private $_gradient = [
-        10 => '#d6e685',
-        33 => '#8cc665',
-        66 => '#44a340',
-        90 => '#1e6823'
+        10 => '#FAD961',
+        90 => '#F76B1C'
     ];
     /**
      * @var array log messages extracted to array as models, to use with data provider.
@@ -172,8 +170,8 @@ class TimelinePanel extends Panel
     }
 
     /**
-     * Sets color indicators.
-     * key: percentages of time request, value: hex color ToDo
+     * Sets color indicators svg graph,
+     * key: percentages of memory used, value: hex color
      * @param array $colors
      */
     public function setGradient($colors)
@@ -183,8 +181,8 @@ class TimelinePanel extends Panel
     }
 
     /**
-     * Color indicators item profile,
-     * key: percentages of time request, value: hex color ToDo
+     * Color indicators svg graph,
+     * key: percentages of memory used, value: hex color
      * @return array
      */
     public function getGradient()
@@ -211,7 +209,7 @@ class TimelinePanel extends Panel
     }
 
     /**
-     * Used memory in request
+     * Memory peak in request, bytes. (obtained by memory_get_peak_usage(true))
      * @return int
      * @since 2.0.8
      */

--- a/panels/TimelinePanel.php
+++ b/panels/TimelinePanel.php
@@ -39,6 +39,15 @@ class TimelinePanel extends Panel
         1 => '#8cc665'
     ];
     /**
+     * @var array Color indicators svg graph.
+     */
+    private $_gradient = [
+        10 => '#d6e685',
+        33 => '#8cc665',
+        66 => '#44a340',
+        90 => '#1e6823'
+    ];
+    /**
      * @var array log messages extracted to array as models, to use with data provider.
      */
     private $_models;
@@ -160,6 +169,27 @@ class TimelinePanel extends Panel
     public function getColors()
     {
         return $this->_colors;
+    }
+
+    /**
+     * Sets color indicators.
+     * key: percentages of time request, value: hex color ToDo
+     * @param array $colors
+     */
+    public function setGradient($colors)
+    {
+        asort($colors);
+        $this->_gradient = $colors;
+    }
+
+    /**
+     * Color indicators item profile,
+     * key: percentages of time request, value: hex color ToDo
+     * @return array
+     */
+    public function getGradient()
+    {
+        return $this->_gradient;
     }
 
     /**

--- a/views/default/panels/timeline/detail.php
+++ b/views/default/panels/timeline/detail.php
@@ -1,7 +1,7 @@
 <?php
 /* @var $panel yii\debug\panels\TimelinePanel */
-/* @var $searchModel \yii\debug\models\search\Timeline */
-/* @var $dataProvider \yii\debug\components\TimelineDataProvider */
+/* @var $searchModel \yii\debug\models\timeline\Search */
+/* @var $dataProvider \yii\debug\models\timeline\DataProvider */
 
 use yii\helpers\Html;
 use yii\widgets\ActiveForm;
@@ -41,6 +41,15 @@ TimelineAsset::register($this);
             </button>
         </div>
     </div>
+    <?php if(!Yii::$app->request->isPjax && $panel->svg->hasPoints()):?>
+    <div class="debug-timeline-panel__memory">
+        <div class="range">
+            <attr class="min" title="mb">0.00</attr>
+            <attr class="max"><?=sprintf('%.2f MB', $panel->memory / 1048576)?> </attr>
+        </div>
+        <?=$panel->svg;?>
+    </div>
+    <?php endif;?>
     <div class="debug-timeline-panel__items">
         <?php Pjax::begin(['formSelector' => '#debug-timeline-search', 'linkSelector' => false, 'options' => ['id' => 'debug-timeline-panel__pjax']]); ?>
         <?php if (($models = $dataProvider->models) === []): ?>

--- a/views/default/panels/timeline/detail.php
+++ b/views/default/panels/timeline/detail.php
@@ -44,8 +44,8 @@ TimelineAsset::register($this);
     <?php if(!Yii::$app->request->isPjax && $panel->svg->hasPoints()):?>
     <div class="debug-timeline-panel__memory">
         <div class="range">
-            <attr class="min" title="mb">0.00</attr>
-            <attr class="max"><?=sprintf('%.2f MB', $panel->memory / 1048576)?> </attr>
+            <attr title="mb" style="bottom: 50%;"><span><?= sprintf('%.2f MB', $panel->memory / 2 / 1048576) ?></span></attr>
+            <attr title="mb" style="bottom: 100%;"><span><?= sprintf('%.2f MB', $panel->memory / 1048576) ?></span></attr>
         </div>
         <?=$panel->svg;?>
     </div>
@@ -58,11 +58,22 @@ TimelineAsset::register($this);
             </div>
         <?php else: ?>
             <?php foreach ($models as $key => $model): ?>
+                <?php
+                $memory = null;
+                if (!empty($model['memory'])) {
+                    $memory = ' / <span class="memory">' . sprintf('%.2f', $model['memory'] / 1048576) . '';
+                    if($model['memoryDiff'] !== 0){
+                        $memory .= '<sup><i>' . (($model['memoryDiff'] > 0) ? '+' : '-') . '</i>' . sprintf('%.3f', $model['memoryDiff'] / 1048576).'</sup>';
+                        $memory .= '  MB</span>';
+                    }
+                }
+                ?>
                 <div class="debug-timeline-panel__item">
                     <?php if ($model['child']): ?>
                         <span class="ruler ruler-start" style="height: <?= $model['child'] * 21; ?>px; margin-left: <?= $model['css']['left']; ?>%"></span>
                     <?php endif; ?>
-                    <?= Html::tag('a', '<span class="category">' . Html::encode($model['category']) . ' <span>' . sprintf('%.1f ms', $model['duration']) . '</span></span>', ['tabindex'=>$key+1,'title' => $model['info'], 'class' => $dataProvider->getCssClass($model), 'style' => 'background-color: '.$model['css']['color'].';margin-left:' . $model['css']['left'] . '%;width:' . $model['css']['width'] . '%']); ?>
+                    <?= Html::tag('a', '
+                        <span class="category">' . Html::encode($model['category']) . ' <span>' . sprintf('%.1f ms', $model['duration']) . '</span>'.$memory.'</span>', ['tabindex'=>$key+1,'title' => $model['info'], 'class' => $dataProvider->getCssClass($model), 'style' => 'background-color: '.$model['css']['color'].';margin-left:' . $model['css']['left'] . '%;width:' . $model['css']['width'] . '%']); ?>
                     <?php if ($model['child']): ?>
                         <span class="ruler ruler-end" style="height: <?= $model['child'] * 21; ?>px; margin-left: <?= $model['css']['left'] + $model['css']['width'] . '%'; ?>"></span>
                     <?php endif; ?>

--- a/views/default/panels/timeline/detail.php
+++ b/views/default/panels/timeline/detail.php
@@ -42,11 +42,8 @@ TimelineAsset::register($this);
         </div>
     </div>
     <?php if(!Yii::$app->request->isPjax && $panel->svg->hasPoints()):?>
-    <div class="debug-timeline-panel__memory">
-        <div class="range">
-            <attr title="mb" style="bottom: 50%;"><span><?= sprintf('%.2f MB', $panel->memory / 2 / 1048576) ?></span></attr>
-            <attr title="mb" style="bottom: 100%;"><span><?= sprintf('%.2f MB', $panel->memory / 1048576) ?></span></attr>
-        </div>
+    <div class="debug-timeline-panel__memory" style="height: <?=$panel->svg->y?>px;">
+        <div class="scale" style="bottom: 100%;"><?= sprintf('%.2f MB', $panel->memory / 1048576) ?></div>
         <?=$panel->svg;?>
     </div>
     <?php endif;?>
@@ -61,11 +58,11 @@ TimelineAsset::register($this);
                 <?php
                 $memory = null;
                 if (!empty($model['memory'])) {
-                    $memory = ' / <span class="memory">' . sprintf('%.2f', $model['memory'] / 1048576) . '';
-                    if($model['memoryDiff'] !== 0){
-                        $memory .= '<sup><i>' . (($model['memoryDiff'] > 0) ? '+' : '-') . '</i>' . sprintf('%.3f', $model['memoryDiff'] / 1048576).'</sup>';
-                        $memory .= '  MB</span>';
+                    $diff = null;
+                    if ($model['memoryDiff'] !== 0) {
+                        $diff = ' title="' . (($model['memoryDiff'] > 0) ? '+' : '-') . sprintf('%.3f', $model['memoryDiff'] / 1048576) . '""';
                     }
+                    $memory = ' / <span class="memory"' . $diff . '>' . sprintf('%.2f', $model['memory'] / 1048576) . ' MB</span>';
                 }
                 ?>
                 <div class="debug-timeline-panel__item">
@@ -73,7 +70,7 @@ TimelineAsset::register($this);
                         <span class="ruler ruler-start" style="height: <?= $model['child'] * 21; ?>px; margin-left: <?= $model['css']['left']; ?>%"></span>
                     <?php endif; ?>
                     <?= Html::tag('a', '
-                        <span class="category">' . Html::encode($model['category']) . ' <span>' . sprintf('%.1f ms', $model['duration']) . '</span>'.$memory.'</span>', ['tabindex'=>$key+1,'title' => $model['info'], 'class' => $dataProvider->getCssClass($model), 'style' => 'background-color: '.$model['css']['color'].';margin-left:' . $model['css']['left'] . '%;width:' . $model['css']['width'] . '%']); ?>
+                        <span class="category">' . Html::encode($model['category']) . ' <span>' . sprintf('%.1f ms', $model['duration']) . '</span>'.$memory.'</span>', ['tabindex'=>$key+1,'title' => $model['info'], 'class' => $dataProvider->getCssClass($model), 'style' => 'background-color: '.$model['css']['color'].';margin-left:' . $model['css']['left'] . '%;width:' . $model['css']['width'] . '%', 'data-memory'=>$dataProvider->getMemory($model)]); ?>
                     <?php if ($model['child']): ?>
                         <span class="ruler ruler-end" style="height: <?= $model['child'] * 21; ?>px; margin-left: <?= $model['css']['left'] + $model['css']['width'] . '%'; ?>"></span>
                     <?php endif; ?>


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #34, #121 


![memory](https://cloud.githubusercontent.com/assets/3738201/21441546/9966ffb4-c8a9-11e6-909f-13c46362e722.gif)


## Customer settings
```php
$config['modules']['debug'] = [
    'class' => 'yii\debug\Module',
    'panels' => [
        'timeline' => [
            'class' => 'yii\debug\panels\TimelinePanel',
            'svgOptions' => [
                'y'=>100 // height chart
                'stroke' => '#F76B1C', // stroke color
                'gradient'=> [ // gradient fill
                    0 => '#FBDA61',
                    100 => '#F76B1C'
                ]
            ]
        ]
    ]
]
```
