### PR TITLE
Display ActiveRecord data in UserPanel if applicable

### DIFF
--- a/panels/UserPanel.php
+++ b/panels/UserPanel.php
@@ -10,6 +10,7 @@ namespace yii\debug\panels;
 use Yii;
 use yii\data\ArrayDataProvider;
 use yii\debug\Panel;
+use yii\db\ActiveRecord;
 
 /**
  * Debugger panel that collects and displays user data.
@@ -70,9 +71,14 @@ class UserPanel extends Panel
             ]);
         }
 
+        $attributes = array_keys(get_object_vars($data));
+        if ($data instanceof ActiveRecord) {
+            $attributes = array_keys($data->getAttributes());
+        }
+        
         return [
             'identity' => $data,
-            'attributes' => array_keys(get_object_vars($data)),
+            'attributes' => $attributes,
             'rolesProvider' => $rolesProvider,
             'permissionsProvider' => $permissionsProvider,
         ];


### PR DESCRIPTION
I noticed that my user panel was display a blank page because $attributes was coming up as an empty array. This should handle ActiveRecord models properly

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no minor update
| Breaks BC?    | no
| Tests pass?   | not sure...
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

