### PR TITLE
Fix Serialization of Closure error

### DIFF
--- a/panels/UserPanel.php
+++ b/panels/UserPanel.php
@@ -75,9 +75,13 @@ class UserPanel extends Panel
         if ($data instanceof ActiveRecord) {
             $attributes = array_keys($data->getAttributes());
         }
-        
+
+        foreach ($attributes as $attribute) {
+                $dataIdentity[$attribute] =  $data->getAttribute($attribute);
+        }
+
         return [
-            'identity' => $data,
+            'identity' => $dataIdentity,
             'attributes' => $attributes,
             'rolesProvider' => $rolesProvider,
             'permissionsProvider' => $permissionsProvider,


### PR DESCRIPTION
If set attribute in User model as callback, then we have Exception at  https://github.com/yiisoft/yii2-debug/blob/master/LogTarget.php#L57
`'Serialization of 'Closure' is not allowed' `

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  |  #195
