### PR TITLE
affix memory bar for timeline

### DIFF
--- a/assets/timeline.css
+++ b/assets/timeline.css
@@ -199,6 +199,12 @@
   transition: bottom 0.2s ease;
 }
 
+.debug-timeline-panel.affix .debug-timeline-panel__memory {
+  z-index: 2;
+  position: fixed;
+  top: 0;
+}
+
 
 @media (max-width:767px) {
   .debug-timeline-panel .ruler:nth-child(2n) b{


### PR DESCRIPTION
When hovering over a profiled element the memory bar shows the memory usage at that moment, but the memory bar quickly scrolls out of view. This PR affixes memory bar to the top.

Possible issues for discussion:
1. Should we make this behavior configurable
2. Should the affixed memory bar have a solid background

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -
