### PR TITLE
Fixed condition of adding user panel into core panels list

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -331,8 +331,7 @@ class Module extends \yii\base\Module implements BootstrapInterface
             'timeline' => ['class' => 'yii\debug\panels\TimelinePanel'],
         ];
 
-        $components = Yii::$app->getComponents();
-        if (isset($components['user']['identityClass'])) {
+        if (Yii::$app->has('user') && Yii::$app->user->identityClass) {
             $panels['user'] = ['class' => 'yii\debug\panels\UserPanel'];
         }
         $panels['router'] = ['class' => 'yii\debug\panels\RouterPanel'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

In my case user component is configured by callback:

```php
'components' => [
    'user' => function () {
        return new \yii\web\User([
            'identityClass' => \common\models\User::class,
            'accessChecker' => new \backend\access\Access(),
        ]);
    },
    //...
],
```

This is needed to create custom access checker.
In that case [condition](https://github.com/yiisoft/yii2-debug/blob/b42f33d111614e84fb66951fcb7afbda1464e3bc/Module.php#L335) doesn't work and throws exception.