### PR TITLE
Enh: To remove toolbar when PRINT MODE ON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Yii Framework 2 debug extension Change Log
 
 - Enh #208: All identity models get converted to arrays when saving User panel data now, not just ActiveRecord models (brandonkelly)
 - Enh #208: Identity model packaging for User panels is now done in an `identityData()` method, making it easier for subclasses to customize (brandonkelly) 
-- Enh #218: Hide the debug toolbar when a html-page printed (githubjeka) 
+- Enh #218: Hide the debug toolbar when an HTML page is printed (githubjeka) 
 
 
 2.0.9 February 21, 2017

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 debug extension Change Log
 
 - Enh #208: All identity models get converted to arrays when saving User panel data now, not just ActiveRecord models (brandonkelly)
 - Enh #208: Identity model packaging for User panels is now done in an `identityData()` method, making it easier for subclasses to customize (brandonkelly) 
+- Enh #218: Hide the debug toolbar when a html-page printed (githubjeka) 
 
 
 2.0.9 February 21, 2017

--- a/assets/toolbar.css
+++ b/assets/toolbar.css
@@ -5,6 +5,12 @@
     bottom: 4px;
 }
 
+@media print {
+  .yii-debug-toolbar {
+    display: none !important;
+  }
+}
+
 .yii-debug-toolbar {
     font: 11px Verdana, Arial, sans-serif;
     text-align: left;

--- a/views/default/toolbar.php
+++ b/views/default/toolbar.php
@@ -10,7 +10,7 @@ $firstPanel = reset($panels);
 $url = $firstPanel->getUrl();
 
 ?>
-<div id="yii-debug-toolbar" class="yii-debug-toolbar yii-debug-toolbar_position_<?= $position ?>">
+<div id="yii-debug-toolbar" class="yii-debug-toolbar yii-debug-toolbar_position_<?= $position ?> hidden-print">
     <div class="yii-debug-toolbar__bar">
         <div class="yii-debug-toolbar__block yii-debug-toolbar__title">
             <a href="<?= Url::to(['index']) ?>">

--- a/views/default/toolbar.php
+++ b/views/default/toolbar.php
@@ -10,7 +10,7 @@ $firstPanel = reset($panels);
 $url = $firstPanel->getUrl();
 
 ?>
-<div id="yii-debug-toolbar" class="yii-debug-toolbar yii-debug-toolbar_position_<?= $position ?> hidden-print">
+<div id="yii-debug-toolbar" class="yii-debug-toolbar yii-debug-toolbar_position_<?= $position ?>">
     <div class="yii-debug-toolbar__bar">
         <div class="yii-debug-toolbar__block yii-debug-toolbar__title">
             <a href="<?= Url::to(['index']) ?>">


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/874234/23846369/2f1f8670-07de-11e7-9895-7cebb3bd68f9.png)


Fix to remove toolbar from print page via [css-bootsrap](http://getbootstrap.com/css/#responsive-utilities-print)