### PR TITLE
Limit the height during the opening animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 debug extension Change Log
 - Enh #208: Identity model packaging for User panels is now done in an `identityData()` method, making it easier for subclasses to customize (brandonkelly) 
 - Enh #218: Hide the debug toolbar when an HTML page is printed (githubjeka) 
 - Bug #221: Fixed the decimal point issue in Timeline when using various locales (bashkarev)
+- Bug #223: Limit the height during the opening animation (nkovacs)
 - Enh #225: Added classes to use bootstrap styles for filter inputs in Timeline panel (johonunu)
 
 

--- a/assets/toolbar.css
+++ b/assets/toolbar.css
@@ -58,7 +58,8 @@
 .yii-debug-toolbar.yii-debug-toolbar_active:not(.yii-debug-toolbar_animating) .yii-debug-toolbar__bar {
     overflow: visible;
 }
-.yii-debug-toolbar:not(.yii-debug-toolbar_active) .yii-debug-toolbar__bar {
+.yii-debug-toolbar:not(.yii-debug-toolbar_active) .yii-debug-toolbar__bar,
+.yii-debug-toolbar.yii-debug-toolbar_animating .yii-debug-toolbar__bar {
     height:40px;
 }
 


### PR DESCRIPTION
Prevents the toolbar from jumping up during the animation,
which is caused by the animating width not being enough to hold
all the elements.
If the fully open toolbar can't hold everything in one line,
the toolbar will still jump up after the animation is done,
but it's less jarring than before.

Fixes #223

| Q             | A
| ------------- | ---
| Is bugfix?    | yey
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | n/a
| Fixed issues  | #223
