### PR TITLE
Timeline panel - make inputs in bootstrap style

### DIFF
--- a/views/default/panels/timeline/detail.php
+++ b/views/default/panels/timeline/detail.php
@@ -14,15 +14,15 @@ TimelineAsset::register($this);
 ?>
 <h1 class="debug-timeline-panel__title">Timeline - <?= number_format($panel->getDuration()); ?> ms</h1>
 
-<?php $form = ActiveForm::begin(['method' => 'get', 'action' => $panel->getUrl(), 'id' => 'debug-timeline-search', 'enableClientScript' => false, 'options' => ['class' => 'debug-timeline-panel__search']]); ?>
+<?php $form = ActiveForm::begin(['method' => 'get', 'action' => $panel->getUrl(), 'id' => 'debug-timeline-search form-inline', 'enableClientScript' => false, 'options' => ['class' => 'debug-timeline-panel__search']]); ?>
 <div class="duration">
     <?= Html::activeLabel($searchModel, 'duration') ?>
-    <?= Html::activeInput('number', $searchModel, 'duration', ['min' => 0, 'size' => '3']); ?>
+    <?= Html::activeInput('number', $searchModel, 'duration', ['min' => 0, 'size' => '3','class'=>'form-control']); ?>
     <span>ms</span>
 </div>
 <div class="category">
     <?= Html::activeLabel($searchModel, 'category') ?>
-    <?= Html::activeTextInput($searchModel, 'category'); ?>
+    <?= Html::activeTextInput($searchModel, 'category',['class'=>'form-control']); ?>
 </div>
 <?php ActiveForm::end(); ?>
 <div class="debug-timeline-panel">

--- a/views/default/panels/timeline/detail.php
+++ b/views/default/panels/timeline/detail.php
@@ -17,12 +17,12 @@ TimelineAsset::register($this);
 <?php $form = ActiveForm::begin(['method' => 'get', 'action' => $panel->getUrl(), 'id' => 'debug-timeline-search form-inline', 'enableClientScript' => false, 'options' => ['class' => 'debug-timeline-panel__search']]); ?>
 <div class="duration">
     <?= Html::activeLabel($searchModel, 'duration') ?>
-    <?= Html::activeInput('number', $searchModel, 'duration', ['min' => 0, 'size' => '3','class'=>'form-control']); ?>
+    <?= Html::activeInput('number', $searchModel, 'duration', ['min' => 0, 'size' => '3', 'class'=>'form-control']); ?>
     <span>ms</span>
 </div>
 <div class="category">
     <?= Html::activeLabel($searchModel, 'category') ?>
-    <?= Html::activeTextInput($searchModel, 'category',['class'=>'form-control']); ?>
+    <?= Html::activeTextInput($searchModel, 'category', ['class'=>'form-control']); ?>
 </div>
 <?php ActiveForm::end(); ?>
 <div class="debug-timeline-panel">


### PR DESCRIPTION
Make input fields in bootstrap style for timeline panel.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

Screenshoot:
![timeline](https://cloud.githubusercontent.com/assets/320024/24566036/0f451e0e-1658-11e7-9cf0-fb0714f40537.png)

