### PR TITLE
Fixes #242 by omitting AssetsPanel creation when yii/web/AssetManager not being used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.0.10 under development
 ------------------------
 
+- Bug #242: Fixed silent crash by omitting AssetsPanel creation when yii/web/AssetManager not being used like in REST apps (tunecino)
 - Enh #208: All identity models get converted to arrays when saving User panel data now, not just ActiveRecord models (brandonkelly)
 - Enh #208: Identity model packaging for User panels is now done in an `identityData()` method, making it easier for subclasses to customize (brandonkelly) 
 - Enh #218: Hide the debug toolbar when an HTML page is printed (githubjeka) 

--- a/panels/AssetPanel.php
+++ b/panels/AssetPanel.php
@@ -50,7 +50,11 @@ class AssetPanel extends Panel
      */
     public function save()
     {
-        $bundles = Yii::$app->view->assetManager->bundles;
+        try {
+            $bundles = Yii::$app->view->assetManager->bundles;
+        } catch (\Exception $e) {
+            $bundles = null;
+        }
         if (empty($bundles)) { // bundles can be false
             return [];
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | uncovered but should pass
| Fixed issues  | #242

Details in https://github.com/yiisoft/yii2-debug/issues/242. Related to app structures not implementing HTML or assets like REST apps.