### PR TITLE
Fix triple-click via firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Yii Framework 2 debug extension Change Log
 - Bug #226: Fixed issue in user panel when you use custom RBAC module that does not implement `\yii\rbac\ManagerInterface` (pana1990)
 - Enh #204: Switch users from the panel (sam002)
 - Bug #236: Fixed rendering AJAX errors to use `innerText` instead of `innerHTML` (samdark)
-- Enh #244: Fixed copy query via triple-click in firefox browser (arzzen)
+- Enh #244: Fixed copying SQL via triple-click in Firefox (arzzen)
 
 
 2.0.9 February 21, 2017

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Yii Framework 2 debug extension Change Log
 - Bug #226: Fixed issue in user panel when you use custom RBAC module that does not implement `\yii\rbac\ManagerInterface` (pana1990)
 - Enh #204: Switch users from the panel (sam002)
 - Bug #236: Fixed rendering AJAX errors to use `innerText` instead of `innerHTML` (samdark)
-- Enh #244: Fixed copying SQL via triple-click in Firefox (arzzen)
+- Bug #244: Fixed copying SQL via triple-click in Firefox (arzzen)
 
 
 2.0.9 February 21, 2017

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Yii Framework 2 debug extension Change Log
 - Bug #226: Fixed issue in user panel when you use custom RBAC module that does not implement `\yii\rbac\ManagerInterface` (pana1990)
 - Enh #204: Switch users from the panel (sam002)
 - Bug #236: Fixed rendering AJAX errors to use `innerText` instead of `innerHTML` (samdark)
-- Fix #244: Fixed copy query via triple-click in firefox browser (arzzen)
+- Enh #244: Fixed copy query via triple-click in firefox browser (arzzen)
 
 
 2.0.9 February 21, 2017

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Yii Framework 2 debug extension Change Log
 - Bug #226: Fixed issue in user panel when you use custom RBAC module that does not implement `\yii\rbac\ManagerInterface` (pana1990)
 - Enh #204: Switch users from the panel (sam002)
 - Bug #236: Fixed rendering AJAX errors to use `innerText` instead of `innerHTML` (samdark)
+- Fix #244: Fixed copy query via triple-click in firefox browser (arzzen)
 
 
 2.0.9 February 21, 2017

--- a/views/default/panels/db/detail.php
+++ b/views/default/panels/db/detail.php
@@ -51,7 +51,7 @@ echo GridView::widget([
         [
             'attribute' => 'query',
             'value' => function ($data) use ($hasExplain, $panel) {
-                $query = Html::encode($data['query']);
+                $query = Html::tag('div', Html::encode($data['query']));
 
                 if (!empty($data['trace'])) {
                     $query .= Html::ul($data['trace'], [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -

Fix triple-click on copy db queries from debug panel (db section) in [firefox browser](https://en.wikipedia.org/wiki/Triple-click#Firefox_3.5)
