### PR TITLE
Fixes #251: User panel was displaying current user info instead of user info at the moment of request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.0.10 under development
 ------------------------
 
+- Bug #251: User panel was displaying current user info instead of user info at the moment of request (samdark) 
 - Bug #242: Fixed silent crash by omitting AssetsPanel creation when yii/web/AssetManager not being used like in REST apps (tunecino)
 - Enh #208: All identity models get converted to arrays when saving User panel data now, not just ActiveRecord models (brandonkelly)
 - Enh #208: Identity model packaging for User panels is now done in an `identityData()` method, making it easier for subclasses to customize (brandonkelly) 

--- a/models/UserSwitch.php
+++ b/models/UserSwitch.php
@@ -25,12 +25,12 @@ class UserSwitch extends Model
     /**
      * @var User user which we are currently switched to
      */
-    private $user;
+    private $_user;
 
     /**
      * @var User the main user who was originally logged in before switching.
      */
-    private $mainUser;
+    private $_mainUser;
 
 
     /**
@@ -60,10 +60,10 @@ class UserSwitch extends Model
      */
     public function getUser()
     {
-        if (empty($this->user)) {
-            $this->user = Yii::$app->get('user');
+        if ($this->_user === null) {
+            $this->_user = Yii::$app->get('user');
         }
-        return $this->user;
+        return $this->_user;
     }
 
     /**
@@ -72,23 +72,23 @@ class UserSwitch extends Model
      */
     public function getMainUser()
     {
-        $session = Yii::$app->getSession();
-        $user = $this->getUser();
+        $currentUser = $this->getUser();
 
-        if (empty($this->mainUser) && $user->getIsGuest() === false) {
+        if ($this->_mainUser === null && $currentUser->getIsGuest() === false) {
+            $session = Yii::$app->getSession();
             if ($session->has('main_user')) {
                 $mainUserId = $session->get('main_user');
-                $mainIdentity = call_user_func([$user->identityClass, 'findIdentity'], $mainUserId);
+                $mainIdentity = call_user_func([$currentUser->identityClass, 'findIdentity'], $mainUserId);
             } else {
-                $mainIdentity = $user->identity;
+                $mainIdentity = $currentUser->identity;
             }
 
-            $mainUser = clone $user;
+            $mainUser = clone $currentUser;
             $mainUser->setIdentity($mainIdentity);
-            $this->mainUser = $mainUser;
+            $this->_mainUser = $mainUser;
         }
 
-        return $this->mainUser;
+        return $this->_mainUser;
     }
 
     /**

--- a/views/default/panels/user/detail.php
+++ b/views/default/panels/user/detail.php
@@ -11,9 +11,7 @@ use yii\widgets\DetailView;
 <h1>User</h1>
 
 <?php
-
-if (!Yii::$app->user->isGuest) {
-
+if (isset($panel->data['identity'], $panel->data['attributes'])) {
     $items = [
         [
             'label'   => 'User',
@@ -47,4 +45,6 @@ if (!Yii::$app->user->isGuest) {
         'items' => $items,
     ]);
 
+} else {
+    echo 'Is guest.';
 } ?>

--- a/views/default/panels/user/summary.php
+++ b/views/default/panels/user/summary.php
@@ -5,15 +5,15 @@
 ?>
 <div class="yii-debug-toolbar__block">
     <a href="<?= $panel->getUrl() ?>">
-        <?php if (Yii::$app->user->isGuest): ?>
+        <?php if (!isset($panel->data['identity'])): ?>
             <span class="yii-debug-toolbar__label">Guest</span>
         <?php else: ?>
             <?php if ($panel->userSwitch->isMainUser()): ?>
                 User <span
-                        class="yii-debug-toolbar__label yii-debug-toolbar__label_info"><?= Yii::$app->user->id ?></span>
+                        class="yii-debug-toolbar__label yii-debug-toolbar__label_info"><?= $panel->data['identity']['id'] ?></span>
             <?php else: ?>
                 User switching <span
-                        class="yii-debug-toolbar__label yii-debug-toolbar__label_warning"><?= Yii::$app->user->id ?></span>
+                        class="yii-debug-toolbar__label yii-debug-toolbar__label_warning"><?= $panel->data['identity']['id'] ?></span>
             <?php endif; ?>
             <?php if ($panel->canSwitchUser()): ?>
                 <span class="yii-debug-toolbar__switch-icon yii-debug-toolbar__userswitch"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | -
| Fixed issues  | #251
