### PR TITLE
Fixes #262: Fixed issue when identity ID is stored in a field different from `id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.0.11 under development
 ------------------------
 
-- no changes in this release.
+- Bug #262: Fixed issue when identity ID is stored in a field different from `id` (samdark) 
 
 
 2.0.10 September 04, 2017

--- a/panels/UserPanel.php
+++ b/panels/UserPanel.php
@@ -22,6 +22,7 @@ use yii\filters\AccessControl;
 use yii\filters\AccessRule;
 use yii\helpers\ArrayHelper;
 use yii\helpers\VarDumper;
+use yii\web\IdentityInterface;
 
 /**
  * Debugger panel that collects and displays user data.
@@ -259,6 +260,7 @@ class UserPanel extends Panel
         }
 
         return [
+            'id' => $identity->getId(),
             'identity' => $identityData,
             'attributes' => $attributes,
             'rolesProvider' => $rolesProvider,
@@ -297,7 +299,7 @@ class UserPanel extends Panel
     /**
      * Returns the array that should be set on [[\yii\widgets\DetailView::model]]
      *
-     * @param mixed $identity
+     * @param IdentityInterface $identity
      * @return array
      */
     protected function identityData($identity)

--- a/views/default/panels/user/summary.php
+++ b/views/default/panels/user/summary.php
@@ -5,15 +5,15 @@
 ?>
 <div class="yii-debug-toolbar__block">
     <a href="<?= $panel->getUrl() ?>">
-        <?php if (!isset($panel->data['identity'])): ?>
+        <?php if (!isset($panel->data['id'])): ?>
             <span class="yii-debug-toolbar__label">Guest</span>
         <?php else: ?>
             <?php if ($panel->userSwitch->isMainUser()): ?>
                 User <span
-                        class="yii-debug-toolbar__label yii-debug-toolbar__label_info"><?= $panel->data['identity']['id'] ?></span>
+                        class="yii-debug-toolbar__label yii-debug-toolbar__label_info"><?= $panel->data['id'] ?></span>
             <?php else: ?>
                 User switching <span
-                        class="yii-debug-toolbar__label yii-debug-toolbar__label_warning"><?= $panel->data['identity']['id'] ?></span>
+                        class="yii-debug-toolbar__label yii-debug-toolbar__label_warning"><?= $panel->data['id'] ?></span>
             <?php endif; ?>
             <?php if ($panel->canSwitchUser()): ?>
                 <span class="yii-debug-toolbar__switch-icon yii-debug-toolbar__userswitch"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes
| Tests pass?   | -
| Fixed issues  | #262
