### PR TITLE
Fixed calling `isMainUser()` on null regression in 2.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.0.11 under development
 ------------------------
 
-- Bug: Fixed calling `isMainUser()` on null regression in 2.0.10 (samdark)
+- Bug #265: Fixed calling `isMainUser()` on null regression in 2.0.10 (samdark)
 
 2.0.10 September 04, 2017
 -------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.0.11 under development
 ------------------------
 
-- no changes in this release.
-
+- Bug: Fixed calling `isMainUser()` on null regression in 2.0.10 (samdark)
 
 2.0.10 September 04, 2017
 -------------------------

--- a/panels/UserPanel.php
+++ b/panels/UserPanel.php
@@ -22,6 +22,7 @@ use yii\filters\AccessControl;
 use yii\filters\AccessRule;
 use yii\helpers\ArrayHelper;
 use yii\helpers\VarDumper;
+use yii\web\IdentityInterface;
 
 /**
  * Debugger panel that collects and displays user data.
@@ -150,6 +151,10 @@ class UserPanel extends Panel
      */
     public function canSwitchUser()
     {
+        if (Yii::$app->user->isGuest) {
+            return false;
+        }
+
         $allowSwitchUser = false;
 
         $rule = new AccessRule($this->ruleUserSwitch);

--- a/views/default/panels/user/summary.php
+++ b/views/default/panels/user/summary.php
@@ -8,7 +8,7 @@
         <?php if (!isset($panel->data['identity'])): ?>
             <span class="yii-debug-toolbar__label">Guest</span>
         <?php else: ?>
-            <?php if ($panel->userSwitch->isMainUser()): ?>
+            <?php if (Yii::$app->getUser()->isGuest || $panel->userSwitch->isMainUser()): ?>
                 User <span
                         class="yii-debug-toolbar__label yii-debug-toolbar__label_info"><?= $panel->data['identity']['id'] ?></span>
             <?php else: ?>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | ?
| Fixed issues  | #265
