### PR TITLE
Do not force session regeneration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.0.13 under development
 ------------------------
 
-- no changes in this release.
+- Bug #282: Fixed issue where session regeneration of user panel destroys session data from other user components.
 
 
 2.0.12 October 09, 2017

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.0.13 under development
 ------------------------
 
-- Bug #282: Fixed issue where session regeneration of user panel destroys session data from other user components.
+- Bug #282: Fixed issue where session regeneration of user panel destroys session data from other user components (nadar)
 
 
 2.0.12 October 09, 2017

--- a/panels/UserPanel.php
+++ b/panels/UserPanel.php
@@ -72,7 +72,7 @@ class UserPanel extends Panel
     {
         if (
             !$this->isEnabled()
-            || Yii::$app->getUser()->isGuest
+            || Yii::$app->getUser()->getIdentity(false) === null
         ) {
             return;
         }


### PR DESCRIPTION
When using multiple yii\web\Users with different idParams, the session regeneration (which is forced by isGuest) will destroy the session.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes & no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
