### PR TITLE
Fix user detail display, fix #274

### DIFF
--- a/models/UserSwitch.php
+++ b/models/UserSwitch.php
@@ -32,6 +32,12 @@ class UserSwitch extends Model
      */
     private $_mainUser;
 
+    /**
+     * @var string|User ID of the user component or a user object
+     * @since 2.0.13
+     */
+    public $userComponent = 'user';
+
 
     /**
      * @inheritdoc
@@ -61,7 +67,8 @@ class UserSwitch extends Model
     public function getUser()
     {
         if ($this->_user === null) {
-            $this->_user = Yii::$app->get('user');
+            /* @var $user User */
+            $this->_user = is_string($this->userComponent) ? Yii::$app->get($this->userComponent, false) : $this->userComponent;
         }
         return $this->_user;
     }
@@ -100,7 +107,7 @@ class UserSwitch extends Model
         // Check if user is currently active one
         $isCurrent = ($user->getId() === $this->getMainUser()->getId());
         // Switch identity
-        Yii::$app->getUser()->switchIdentity($user->identity);
+        $this->getUser()->switchIdentity($user->identity);
         if (!$isCurrent) {
             Yii::$app->getSession()->set('main_user', $this->getMainUser()->getId());
         } else {

--- a/panels/UserPanel.php
+++ b/panels/UserPanel.php
@@ -23,6 +23,7 @@ use yii\filters\AccessRule;
 use yii\helpers\ArrayHelper;
 use yii\helpers\VarDumper;
 use yii\web\IdentityInterface;
+use yii\web\User;
 
 /**
  * Debugger panel that collects and displays user data.
@@ -64,6 +65,11 @@ class UserPanel extends Panel
      */
     public $filterColumns = [];
 
+    /**
+     * @var string|User ID of the user component or a user object
+     * @since 2.0.13
+     */
+    public $userComponent = 'user';
 
     /**
      * @inheritdoc
@@ -72,12 +78,12 @@ class UserPanel extends Panel
     {
         if (
             !$this->isEnabled()
-            || Yii::$app->getUser()->isGuest
+            || $this->getUser()->isGuest
         ) {
             return;
         }
 
-        $this->userSwitch = new UserSwitch();
+        $this->userSwitch = new UserSwitch(['userComponent' => $this->userComponent]);
         $this->addAccesRules();
 
         if (!is_object($this->filterModel)
@@ -85,12 +91,22 @@ class UserPanel extends Panel
             && in_array('yii\debug\models\search\UserSearchInterface', class_implements($this->filterModel), true)
         ) {
             $this->filterModel = new $this->filterModel;
-        } elseif (Yii::$app->user && Yii::$app->user->identityClass) {
-            if (is_subclass_of(Yii::$app->user->identityClass, ActiveRecord::className())) {
+        } elseif ($this->getUser() && $this->getUser()->identityClass) {
+            if (is_subclass_of($this->getUser()->identityClass, ActiveRecord::className())) {
                 $this->filterModel = new \yii\debug\models\search\User();
             }
         }
 
+    }
+
+    /**
+     * @return User|null
+     * @since 2.0.13
+     */
+    public function getUser()
+    {
+        /* @var $user User */
+        return is_string($this->userComponent) ? Yii::$app->get($this->userComponent, false) : $this->userComponent;
     }
 
     /**
@@ -150,7 +166,7 @@ class UserPanel extends Panel
      */
     public function canSwitchUser()
     {
-        if (Yii::$app->user->isGuest) {
+        if ($this->getUser()->isGuest) {
             return false;
         }
 
@@ -219,7 +235,7 @@ class UserPanel extends Panel
             $authManager = Yii::$app->getAuthManager();
 
             if ($authManager instanceof \yii\rbac\ManagerInterface) {
-                $roles = ArrayHelper::toArray($authManager->getRolesByUser(Yii::$app->getUser()->id));
+                $roles = ArrayHelper::toArray($authManager->getRolesByUser($this->getUser()->id));
                 foreach ($roles as &$role) {
                     $role['data'] = $this->dataToString($role['data']);
                 }
@@ -228,7 +244,7 @@ class UserPanel extends Panel
                     'allModels' => $roles,
                 ]);
 
-                $permissions = ArrayHelper::toArray($authManager->getPermissionsByUser(Yii::$app->getUser()->id));
+                $permissions = ArrayHelper::toArray($authManager->getPermissionsByUser($this->getUser()->id));
                 foreach ($permissions as &$permission) {
                     $permission['data'] = $this->dataToString($permission['data']);
                 }
@@ -277,7 +293,7 @@ class UserPanel extends Panel
     public function isEnabled()
     {
         try {
-            Yii::$app->getUser();
+            $this->getUser();
         } catch (InvalidConfigException $exception) {
             return false;
         }

--- a/views/default/panels/user/detail.php
+++ b/views/default/panels/user/detail.php
@@ -11,7 +11,7 @@ use yii\widgets\DetailView;
 <h1>User</h1>
 
 <?php
-if (isset($panel->data['identity'], $panel->data['attributes'])) {
+if (isset($panel->data['identity'])) {
     $items = [
         [
             'label'   => 'User',

--- a/views/default/panels/user/summary.php
+++ b/views/default/panels/user/summary.php
@@ -8,7 +8,7 @@
         <?php if (!isset($panel->data['id'])): ?>
             <span class="yii-debug-toolbar__label">Guest</span>
         <?php else: ?>
-            <?php if (Yii::$app->getUser()->isGuest || $panel->userSwitch->isMainUser()): ?>
+            <?php if ($panel->getUser()->isGuest || $panel->userSwitch->isMainUser()): ?>
                 User <span
                         class="yii-debug-toolbar__label yii-debug-toolbar__label_info"><?= $panel->data['id'] ?></span>
             <?php else: ?>


### PR DESCRIPTION
In case of a user not represented by a model the display was wrongly displaying `is guest`.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | 
| Fixes issues | #285

