### PR TITLE
General Info table on Request panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 debug extension Change Log
 - Enh #283: Send debug headers in AJAX requests in order to be able to link to debug panel from single page apps (glendemon)
 - Chg #292: Added PHP 7.2 compatibility (brandonkelly) 
 - Chg: Changed `default/view` not to depend on `db` panel (silverfire)
+- Enh: Added a "General Info" table to the Request panel.
 
 
 2.0.12 October 09, 2017

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Yii Framework 2 debug extension Change Log
 - Enh #283: Send debug headers in AJAX requests in order to be able to link to debug panel from single page apps (glendemon)
 - Chg #292: Added PHP 7.2 compatibility (brandonkelly) 
 - Chg: Changed `default/view` not to depend on `db` panel (silverfire)
-- Enh: Added a "General Info" table to the Request panel.
+- Enh #294: Added a "General Info" table to the Request panel (brandonkelly)
 
 
 2.0.12 October 09, 2017

--- a/panels/RequestPanel.php
+++ b/panels/RequestPanel.php
@@ -102,6 +102,13 @@ class RequestPanel extends Panel
             'route' => Yii::$app->requestedAction ? Yii::$app->requestedAction->getUniqueId() : Yii::$app->requestedRoute,
             'action' => $action,
             'actionParams' => Yii::$app->requestedParams,
+            'general' => [
+                'method' => Yii::$app->getRequest()->getMethod(),
+                'isAjax' => Yii::$app->getRequest()->getIsAjax(),
+                'isPjax' => Yii::$app->getRequest()->getIsPjax(),
+                'isFlash' => Yii::$app->getRequest()->getIsFlash(),
+                'isSecureConnection' => Yii::$app->getRequest()->getIsSecureConnection(),
+            ],
             'requestBody' => Yii::$app->getRequest()->getRawBody() == '' ? [] : [
                 'Content Type' => Yii::$app->getRequest()->getContentType(),
                 'Raw' => Yii::$app->getRequest()->getRawBody(),

--- a/views/default/panels/request/detail.php
+++ b/views/default/panels/request/detail.php
@@ -7,7 +7,13 @@ echo '<h1>Request</h1>';
 
 $items = [];
 
-$parametersContent = $this->render('table', [
+$parametersContent = '';
+
+if (isset($panel->data['general'])) {
+    $parametersContent .= $this->render('table', ['caption' => 'General Info', 'values' => $panel->data['general']]);
+}
+
+$parametersContent .= $this->render('table', [
     'caption' => 'Routing',
     'values' => [
         'Route' => $panel->data['route'],


### PR DESCRIPTION
This PR adds a new “General Info” table on the Request panel (Parameters tab).

The table displays the following Request values:

- `method`
- `isAjax`
- `isPjax`
- `isFlash`
- `isSecureConnection`

While technically everything here could be determined by looking at other Request panel info, none of it is obvious, as there is logic that goes into these getter methods based on HTTP headers, etc.

We found ourselves needing this, especially the `isSecureConnection` row, when working to update our project for the new secure headers feature in Yii 2.0.13. Having that info readily available should save others some time.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
