### PR TITLE
Fixes #302: Debug panel with suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.0.14 under development
 ------------------------
 
-- no changes in this release.
+- Bug #302: Fixed panel usage with suffixes in UrlManager (kyrylo-permiakov)
 
 
 2.0.13 December 5, 2017

--- a/Module.php
+++ b/Module.php
@@ -199,11 +199,13 @@ class Module extends \yii\base\Module implements BootstrapInterface
                 'class' => 'yii\web\UrlRule',
                 'route' => $this->id,
                 'pattern' => $this->id,
+                'suffix' => false
             ],
             [
                 'class' => 'yii\web\UrlRule',
                 'route' => $this->id . '/<controller>/<action>',
                 'pattern' => $this->id . '/<controller:[\w\-]+>/<action:[\w\-]+>',
+                'suffix' => false
             ]
         ], false);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #302 

@samdark I've tested this with any suffixes from UrlManager and it works great. I don't know - is it a good solution to turn off suffix for debug panel always, but seems like it always doesn't need it. 
