### PR TITLE
prevent multiple lines in toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.0.14 under development
 ------------------------
 
+- Enh #316: Prevent multiple lines in toolbar (ZAYEC77)
 - Bug #302: Fixed panel usage with suffixes in UrlManager (kyrylo-permiakov)
 - Enh #311: Adjusted module's code to use `->get()` for dependencies (samdark)
 - Enh #77: Added "Events" panel (klimov-paul)

--- a/src/assets/toolbar.css
+++ b/src/assets/toolbar.css
@@ -127,7 +127,10 @@
     font-weight: normal;
     line-height: 14px;
     white-space: nowrap;
-    vertical-align: baseline;
+    vertical-align: middle;
+    max-width: 100px;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
     color: #ffffff;
     text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
     background-color: #999999;


### PR DESCRIPTION
This style fix should limit the width of wide labels, prevents formation of multiple lines in toolbar

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

Before:
![image](https://user-images.githubusercontent.com/4509483/38865032-49b2b208-4245-11e8-9f7b-9a65dc795afd.png)

After:
![image](https://user-images.githubusercontent.com/4509483/38865000-31ee46c8-4245-11e8-83a4-906f540e1403.png)

it's just proposed, maybe we can find some better way to optimize this view
