### PR TITLE
Added alt tag to debug toolbar image

### DIFF
--- a/src/views/default/toolbar.php
+++ b/src/views/default/toolbar.php
@@ -15,7 +15,7 @@ $url = $firstPanel->getUrl();
     <div class="yii-debug-toolbar__bar">
         <div class="yii-debug-toolbar__block yii-debug-toolbar__title">
             <a href="<?= Url::to(['index']) ?>">
-                <img width="30" height="30" alt="" src="<?= \yii\debug\Module::getYiiLogo() ?>">
+                <img width="30" height="30" alt="Yii" src="<?= \yii\debug\Module::getYiiLogo() ?>">
             </a>
         </div>
 


### PR DESCRIPTION
not super relevant, but I noticed it when activating a CSS style to higlight images without alt tag on my site.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | n/a
