### PR TITLE
Fixes #327: set the active class before setting display:block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Yii Framework 2 debug extension Change Log
 - Enh #77: Added "Events" panel (klimov-paul)
 - Enh #301: Added configuration option to toggle IP address restriction warning on / off (jkrasniewski)
 - Bug #300: Fixed email files are not deleted by GC (pistej)
+- Bug #327: Fix animation on page load when the toolbar is expanded (brandonkelly)
 
 
 2.0.13 December 5, 2017

--- a/src/assets/toolbar.js
+++ b/src/assets/toolbar.js
@@ -137,11 +137,11 @@
                 }
             };
 
-        toolbarEl.style.display = 'block';
-
         if (restoreStorageState(CACHE_KEY) === ACTIVE_STATE) {
             toolbarEl.classList.add(activeClass);
         }
+
+        toolbarEl.style.display = 'block';
 
         window.onresize = function () {
             if (toolbarEl.classList.contains(iframeActiveClass)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #327 
