### PR TITLE
fix error when trace is missing from message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Yii Framework 2 debug extension Change Log
 - Enh #301: Added configuration option to toggle IP address restriction warning on / off (jkrasniewski)
 - Bug #300: Fixed email files are not deleted by GC (pistej)
 - Bug #327: Fix animation on page load when the toolbar is expanded (brandonkelly)
+- Bug #332: Fix error when trace is missing from message (cornernote)
 
 
 2.0.13 December 5, 2017

--- a/src/panels/LogPanel.php
+++ b/src/panels/LogPanel.php
@@ -102,7 +102,7 @@ class LogPanel extends Panel
                     'level' => $message[1],
                     'category' => $message[2],
                     'time' => $message[3] * 1000, // time in milliseconds
-                    'trace' => $message[4]
+                    'trace' => isset($message[4]) ? $message[4] : [],
                 ];
             }
         }


### PR DESCRIPTION
`yii\log\Target` can sometimes set a message without the `trace` (`index=4`) element in the array, eg:

https://github.com/yiisoft/yii2/blob/master/framework/log/Target.php#L128

```
if (($context = $this->getContextMessage()) !== '') {
    $this->messages[] = [$context, Logger::LEVEL_INFO, 'application', YII_BEGIN_TIME];
}
```

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #332 
