### PR TITLE
added PR #309 dump panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.1.0 under development
 ------------------------
 
+- Enh #247, #309: Added dump panel that collects and displays debug messages with `Logger::LEVEL_TRACE` (pistej, simialbi)
 - Bug #343: Fixed errors on "Roles and permissions" tab (simialbi)
 - Enh #296, #326, #340: Removed bootstrap as dependency, bundled Bootstrap 4 (simialbi)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.1.0 under development
 ------------------------
 
-- Enh #247, #309: Added dump panel that collects and displays debug messages with `Logger::LEVEL_TRACE` (pistej, simialbi)
+- Enh #247: Added dump panel that collects and displays debug messages with `Logger::LEVEL_TRACE` (pistej, simialbi)
 - Bug #343: Fixed errors on "Roles and permissions" tab (simialbi)
 - Enh #296, #326, #340: Removed bootstrap as dependency, bundled Bootstrap 4 (simialbi)
 

--- a/src/Module.php
+++ b/src/Module.php
@@ -357,6 +357,7 @@ class Module extends \yii\base\Module implements BootstrapInterface
             'timeline' => ['class' => 'yii\debug\panels\TimelinePanel'],
             'user' => ['class' => 'yii\debug\panels\UserPanel'],
             'router' => ['class' => 'yii\debug\panels\RouterPanel'],
+            'dump' => ['class' => 'yii\debug\panels\DumpPanel'],
         ];
     }
 

--- a/src/panels/DumpPanel.php
+++ b/src/panels/DumpPanel.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\debug\panels;
+
+use Yii;
+use yii\log\Logger;
+use yii\debug\models\search\Log;
+use yii\debug\Panel;
+use yii\helpers\VarDumper;
+
+/**
+ * Dump panel that collects and displays debug messages (Logger::LEVEL_TRACE).
+ *
+ * @author Pistej <pistej2@gmail.com>
+ * @since 2.1.0
+ */
+class DumpPanel extends Panel
+{
+    /**
+     * @var array the message categories to filter by. If empty array, it means
+     * all categories are allowed
+     */
+    public $categories = ['application'];
+
+    /**
+     * @var bool whether the result should be syntax-highlighted
+     */
+    public $highlight = true;
+
+    /**
+     * @var int maximum depth that the dumper should go into the variable
+     */
+    public $depth = 10;
+
+    /**
+     * @var array log messages extracted to array as models, to use with data provider.
+     */
+    private $_models;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'Dump';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSummary()
+    {
+        return Yii::$app->view->render('panels/dump/summary', ['panel' => $this]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDetail()
+    {
+        $searchModel = new Log();
+        $dataProvider = $searchModel->search(Yii::$app->request->getQueryParams(), $this->getModels());
+
+        return Yii::$app->view->render('panels/dump/detail', [
+            'dataProvider' => $dataProvider,
+            'panel' => $this,
+            'searchModel' => $searchModel,
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save()
+    {
+        $target = $this->module->logTarget;
+        $except = [];
+        if (isset($this->module->panels['router'])) {
+            $except = $this->module->panels['router']->getCategories();
+        }
+
+        $messages = $target->filterMessages($target->messages, Logger::LEVEL_TRACE, $this->categories, $except);
+        foreach ($messages as &$message) {
+            $message[0] = VarDumper::export($message[0]);
+        }
+
+        return $messages;
+    }
+
+    /**
+     * Returns an array of models that represents logs of the current request.
+     * Can be used with data providers, such as \yii\data\ArrayDataProvider.
+     *
+     * @param bool $refresh if need to build models from log messages and refresh them.
+     * @return array models
+     */
+    protected function getModels($refresh = false)
+    {
+        if ($this->_models === null || $refresh) {
+            $this->_models = [];
+
+            foreach ($this->data as $message) {
+                $this->_models[] = [
+                    'message' => $message[0],
+                    'level' => $message[1],
+                    'category' => $message[2],
+                    'time' => $message[3] * 1000, // time in milliseconds
+                    'trace' => $message[4]
+                ];
+            }
+        }
+
+        return $this->_models;
+    }
+}

--- a/src/panels/DumpPanel.php
+++ b/src/panels/DumpPanel.php
@@ -11,12 +11,12 @@ use Yii;
 use yii\log\Logger;
 use yii\debug\models\search\Log;
 use yii\debug\Panel;
-use yii\helpers\VarDumper;
 
 /**
  * Dump panel that collects and displays debug messages (Logger::LEVEL_TRACE).
  *
  * @author Pistej <pistej2@gmail.com>
+ * @author Simon Karlen <simi.albi@outlook.com>
  * @since 2.1.0
  */
 class DumpPanel extends Panel
@@ -85,9 +85,6 @@ class DumpPanel extends Panel
         }
 
         $messages = $target->filterMessages($target->messages, Logger::LEVEL_TRACE, $this->categories, $except);
-        foreach ($messages as &$message) {
-            $message[0] = VarDumper::export($message[0]);
-        }
 
         return $messages;
     }

--- a/src/views/default/panels/dump/detail.php
+++ b/src/views/default/panels/dump/detail.php
@@ -1,0 +1,50 @@
+<?php
+
+use yii\helpers\Html;
+use yii\grid\GridView;
+use yii\helpers\VarDumper;
+
+/* @var $panel yii\debug\panels\DumpPanel */
+/* @var $searchModel yii\debug\models\search\Log */
+/* @var $dataProvider yii\data\ArrayDataProvider */
+?>
+    <h1>Dump</h1>
+<?php
+
+echo GridView::widget([
+    'dataProvider' => $dataProvider,
+    'id' => 'dump-panel-detailed-grid',
+    'options' => ['class' => 'detail-grid-view table-responsive'],
+    'filterModel' => $searchModel,
+    'filterUrl' => $panel->getUrl(),
+    'columns' => [
+        'category',
+        [
+            'attribute' => 'message',
+            'value' => function ($data) use ($panel) {
+                $message = eval('return ' . $data['message'] . ';');
+
+                $message = VarDumper::dumpAsString($message, $panel->depth, $panel->highlight);
+                //don't encode highlighted variables
+                if (!$panel->highlight) {
+                    $message = Html::encode($message);
+                }
+
+                if (!empty($data['trace'])) {
+                    $message .= Html::ul($data['trace'], [
+                        'class' => 'trace',
+                        'item' => function ($trace) use ($panel) {
+                            return '<li>' . $panel->getTraceLine($trace) . '</li>';
+                        },
+                    ]);
+                }
+
+                return $message;
+            },
+            'format' => 'raw',
+            'options' => [
+                'width' => '80%',
+            ],
+        ],
+    ],
+]);

--- a/src/views/default/panels/dump/detail.php
+++ b/src/views/default/panels/dump/detail.php
@@ -22,9 +22,7 @@ echo GridView::widget([
         [
             'attribute' => 'message',
             'value' => function ($data) use ($panel) {
-                $message = eval('return ' . $data['message'] . ';');
-
-                $message = VarDumper::dumpAsString($message, $panel->depth, $panel->highlight);
+                $message = VarDumper::dumpAsString($data['message'], $panel->depth, $panel->highlight);
                 //don't encode highlighted variables
                 if (!$panel->highlight) {
                     $message = Html::encode($message);

--- a/src/views/default/panels/dump/summary.php
+++ b/src/views/default/panels/dump/summary.php
@@ -1,0 +1,10 @@
+<?php
+/* @var $panel yii\debug\panels\AssetPanel */
+if (!empty($panel->data)):
+    ?>
+    <div class="yii-debug-toolbar__block">
+        <a href="<?= $panel->getUrl() ?>" title="Number of dumped variables">Dump
+            <span class="yii-debug-toolbar__label yii-debug-toolbar__label_info"><?= count($panel->data) ?></span>
+        </a>
+    </div>
+<?php endif; ?>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌ 
| New feature?  | ✔️ 
| Breaks BC?    | ❌ 
| Tests pass?   | ✔️ 
| Fixed issues  | PR #309, #247 

Working demo: [http://demo.karlen.li/web/](http://demo.karlen.li/web/debug/default/view?panel=dump&tag=5c065aa07d5e9)

Debug calling controller code:
```php
    /**
     * Displays homepage.
     *
     * @return string
     */
    public function actionIndex()
    {
        Yii::debug([
            'test' => 'value',
            'foo' => 'bar',
            'bar' => 'baz'
        ]);
        Yii::debug(null);
        $std = new \stdClass();
        $std->null = null;
        $std->test = 'value';
        $std->integer = 22;
        $std->float = 3.2521553;
        $std->boolean = false;
        $std->array = [
            'test' => 'value',
            'foo' => 'bar',
            'null' => null,
            'integer' => 33,
            'float' => 3.2521553,
            'boolean' => false
        ];
        Yii::debug($std);

        return $this->render('index');
    }
```