### PR TITLE
Fix panel display when mails fail to serialize.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Yii Framework 2 debug extension Change Log
 - Enh #296, #326, #340: Removed bootstrap as dependency, bundled Bootstrap 4 (simialbi)
 - Bug #342: Toolbar animates on every page load in Chrome 70 (ricpelo)
 - Enh #350: Use smaller padding for tables cells (machour)
-
+- Bug #352: Fixed failure to serialize emails causing summary and thus all panels not to render (sammousa)
 
 2.0.14 September 24, 2018
 -------------------------

--- a/src/panels/MailPanel.php
+++ b/src/panels/MailPanel.php
@@ -108,7 +108,7 @@ class MailPanel extends Panel
     {
         return Yii::$app->view->render('panels/mail/summary', [
             'panel' => $this,
-            'mailCount' => is_array($this->data) ? count($this->data) : 0,
+            'mailCount' => is_array($this->data) ? count($this->data) : ⚠️,
         ]);
     }
 

--- a/src/panels/MailPanel.php
+++ b/src/panels/MailPanel.php
@@ -108,7 +108,7 @@ class MailPanel extends Panel
     {
         return Yii::$app->view->render('panels/mail/summary', [
             'panel' => $this,
-            'mailCount' => count($this->data),
+            'mailCount' => is_array($this->data) ? count($this->data) : 0,
         ]);
     }
 


### PR DESCRIPTION
When mails fail to serialize all debug panels break due to the summary.
This is shown for a panel that is not the mail panel:
```php
PHP Warning 'yii\base\ErrorException' with message 'count(): Parameter must be an array or an object that implements Countable' 

in /project/vendor/yiisoft/yii2-debug/src/panels/MailPanel.php:111

Stack trace:
#0 [internal function]: yii\base\ErrorHandler->handleError(2, 'count(): Parame...', '/project/vendor...', 111, Array)
#1 /project/vendor/yiisoft/yii2-debug/src/panels/MailPanel.php(111): count(NULL)
#2 /project/vendor/yiisoft/yii2-debug/src/views/default/view.php(25): yii\debug\panels\MailPanel->getSummary()
#3 /project/vendor/yiisoft/yii2/base/View.php(348): require('/project/vendor...')
#4 /project/vendor/yiisoft/yii2/base/View.php(257): yii\base\View->renderPhpFile('/project/vendor...', Array)
#5 /project/vendor/yiisoft/yii2/base/View.php(156): yii\base\View->renderFile('/project/vendor...', Array, Object(yii\debug\controllers\DefaultController))
#6 /project/vendor/yiisoft/yii2/base/Controller.php(384): yii\base\View->render('view', Array, Object(yii\debug\controllers\DefaultController))
#7 /project/vendor/yiisoft/yii2-debug/src/controllers/DefaultController.php(121): yii\base\Controller->render('view', Array)
#8 [internal function]: yii\debug\controllers\DefaultController->actionView('5c7e9f3fd6aad', 'router')

```

For the mail panel itself this error is shown:
```php
Exception 'yii\debug\FlattenException' with message 'Serialization of 'Closure' is not allowed' 

in /project/vendor/yiisoft/yii2-debug/src/LogTarget.php:60

Stack trace:
#0 /project/vendor/yiisoft/yii2-debug/src/LogTarget.php(60): serialize(Array)
#1 /project/vendor/yiisoft/yii2-debug/src/LogTarget.php(130): yii\debug\LogTarget->export()
#2 /project/vendor/yiisoft/yii2/log/Dispatcher.php(189): yii\debug\LogTarget->collect(Array, true)
#3 /project/vendor/yiisoft/yii2/log/Logger.php(177): yii\log\Dispatcher->dispatch(Array, true)
#4 [internal function]: yii\log\Logger->flush(true)
#5 {main}
```

While there is no (good) way to serialize a `Closure`, the very least we can do is have other panels still work.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
