### PR TITLE
Enh #390 Better serializer (incl. closures) by using opis/closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.1.6 under development
 -----------------------
 
-- no changes in this release.
+- Enh #390: Use opis/closure to serialize data (Sarke)
 
 
 2.1.5 June 04, 2019

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "require": {
         "php": ">=5.4",
         "ext-mbstring": "*",
-        "yiisoft/yii2": "~2.0.13"
+        "yiisoft/yii2": "~2.0.13",
+        "opis/closure": "^3.3"
     },
     "require-dev": {
         "yiisoft/yii2-swiftmailer": "*",

--- a/src/LogTarget.php
+++ b/src/LogTarget.php
@@ -11,6 +11,7 @@ use Yii;
 use yii\base\InvalidConfigException;
 use yii\helpers\FileHelper;
 use yii\log\Target;
+use Opis\Closure;
 
 /**
  * The debug LogTarget is used to store logs for later use in the debugger tool
@@ -57,7 +58,7 @@ class LogTarget extends Target
         $exceptions = [];
         foreach ($this->module->panels as $id => $panel) {
             try {
-                $data[$id] = serialize($panel->save());
+                $data[$id] = Closure\serialize($panel->save());
             } catch (\Exception $exception) {
                 $exceptions[$id] = new FlattenException($exception);
             }
@@ -65,7 +66,7 @@ class LogTarget extends Target
         $data['summary'] = $summary;
         $data['exceptions'] = $exceptions;
 
-        file_put_contents($dataFile, serialize($data));
+        file_put_contents($dataFile, Closure\serialize($data));
         if ($this->module->fileMode !== null) {
             @chmod($dataFile, $this->module->fileMode);
         }
@@ -96,7 +97,7 @@ class LogTarget extends Target
             // error while reading index data, ignore and create new
             $manifest = [];
         } else {
-            $manifest = unserialize($manifest);
+            $manifest = Closure\unserialize($manifest);
         }
 
         $manifest[$this->tag] = $summary;
@@ -104,7 +105,7 @@ class LogTarget extends Target
 
         ftruncate($fp, 0);
         rewind($fp);
-        fwrite($fp, serialize($manifest));
+        fwrite($fp, Closure\serialize($manifest));
 
         @flock($fp, LOCK_UN);
         @fclose($fp);

--- a/src/Panel.php
+++ b/src/Panel.php
@@ -186,33 +186,13 @@ class Panel extends Component
      * level values. Value 0 means allowing all levels.
      * @param array $categories the message categories to filter by. If empty, it means all categories are allowed.
      * @param array $except the message categories to exclude. If empty, it means all categories are allowed.
-     * @param bool $stringify Convert non-string (such as closures) to strings
      * @return array the filtered messages.
      * @since 2.1.4
      * @see \yii\log\Target::filterMessages()
      */
-    protected function getLogMessages($levels = 0, $categories = [], $except = [], $stringify = false)
+    protected function getLogMessages($levels = 0, $categories = [], $except = [])
     {
         $target = $this->module->logTarget;
-        $messages = $target->filterMessages($target->messages, $levels, $categories, $except);
-
-        if (!$stringify) {
-            return $messages;
-        }
-
-        foreach ($messages as &$message) {
-            if (!isset($message[0]) || is_string($message[0])) {
-                continue;
-            }
-
-            // exceptions may not be serializable if in the call stack somewhere is a Closure
-            if ($message[0] instanceof \Throwable || $message[0] instanceof \Exception) {
-                $message[0] = (string) $message[0];
-            } else {
-                $message[0] = VarDumper::export($message[0]);
-            }
-        }
-
-        return $messages;
+        return $target->filterMessages($target->messages, $levels, $categories, $except);
     }
 }

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -12,6 +12,7 @@ use yii\debug\models\search\Debug;
 use yii\web\Controller;
 use yii\web\NotFoundHttpException;
 use yii\web\Response;
+use Opis\Closure;
 
 /**
  * Debugger controller provides browsing over available debug logs.
@@ -181,7 +182,7 @@ class DefaultController extends Controller
             }
 
             if ($content !== '') {
-                $this->_manifest = array_reverse(unserialize($content), true);
+                $this->_manifest = array_reverse(Closure\unserialize($content), true);
             } else {
                 $this->_manifest = [];
             }
@@ -204,12 +205,12 @@ class DefaultController extends Controller
             $manifest = $this->getManifest($retry > 0);
             if (isset($manifest[$tag])) {
                 $dataFile = $this->module->dataPath . "/$tag.data";
-                $data = unserialize(file_get_contents($dataFile));
+                $data = Closure\unserialize(file_get_contents($dataFile));
                 $exceptions = $data['exceptions'];
                 foreach ($this->module->panels as $id => $panel) {
                     if (isset($data[$id])) {
                         $panel->tag = $tag;
-                        $panel->load(unserialize($data[$id]));
+                        $panel->load(Closure\unserialize($data[$id]));
                     }
                     if (isset($exceptions[$id])) {
                         $panel->setError($exceptions[$id]);

--- a/src/panels/DumpPanel.php
+++ b/src/panels/DumpPanel.php
@@ -89,7 +89,7 @@ class DumpPanel extends Panel
             $except = $this->module->panels['router']->getCategories();
         }
 
-        $messages = $this->getLogMessages(Logger::LEVEL_TRACE, $this->categories, $except, true);
+        $messages = $this->getLogMessages(Logger::LEVEL_TRACE, $this->categories, $except);
 
         return $messages;
     }

--- a/src/panels/LogPanel.php
+++ b/src/panels/LogPanel.php
@@ -67,7 +67,7 @@ class LogPanel extends Panel
             $except = $this->module->panels['router']->getCategories();
         }
 
-        $messages = $this->getLogMessages(Logger::LEVEL_ERROR | Logger::LEVEL_INFO | Logger::LEVEL_WARNING | Logger::LEVEL_TRACE, [], $except, true);
+        $messages = $this->getLogMessages(Logger::LEVEL_ERROR | Logger::LEVEL_INFO | Logger::LEVEL_WARNING | Logger::LEVEL_TRACE, [], $except);
 
         return ['messages' => $messages];
     }

--- a/tests/FlattenExceptionTest.php
+++ b/tests/FlattenExceptionTest.php
@@ -4,6 +4,7 @@ namespace yiiunit\debug;
 
 use yii\debug\FlattenException;
 use yii\web\NotFoundHttpException;
+use Opis\Closure;
 
 /**
  * @author Dmitry Bashkarev <dmitry@bashkarev.com>
@@ -85,7 +86,7 @@ class FlattenExceptionTest extends TestCase
         $dh = opendir(__DIR__);
         $fh = tmpfile();
 
-        $incomplete = unserialize('O:14:"BogusTestClass":0:{}');
+        $incomplete = Closure\unserialize('O:14:"BogusTestClass":0:{}');
 
         $exception = $this->createException([
             (object)['foo' => 1],
@@ -151,7 +152,7 @@ class FlattenExceptionTest extends TestCase
         });
 
         $flattened = new FlattenException($exception);
-        $this->assertContains('Closure', serialize($flattened));
+        $this->assertContains('Closure', Closure\serialize($flattened));
     }
 
     public function testRecursionInArguments()
@@ -162,7 +163,7 @@ class FlattenExceptionTest extends TestCase
 
         $flattened = new FlattenException($exception);
         $trace = $flattened->getTrace();
-        $this->assertContains('*DEEP NESTED ARRAY*', serialize($trace));
+        $this->assertContains('*DEEP NESTED ARRAY*', Closure\serialize($trace));
     }
 
     public function testTooBigArray()
@@ -184,7 +185,7 @@ class FlattenExceptionTest extends TestCase
 
         $this->assertSame($trace[0]['args'][0], ['array', ['array', '*SKIPPED over 10000 entries*']]);
 
-        $serializeTrace = serialize($trace);
+        $serializeTrace = Closure\serialize($trace);
 
         $this->assertContains('*SKIPPED over 10000 entries*', $serializeTrace);
         $this->assertNotContains('*value1*', $serializeTrace);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | kinda
| New feature?  | kinda
| Breaks BC?    | maybe?
| Tests pass?   | yes
| Fixed issues  | #390 

The only BC breaking change was removing the `$stringify` parameter for `Panel::getLogMessages()` that I introduced in 2.1.4.