### PR TITLE
Fix #401 SPL object closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.1.7 under development
 -----------------------
 
-- no changes in this release.
+- Fix #401: Partial revert of #390, use var dumper on dump panel as serializer to deal with closures in SPL Objects (Sarke)
 
 
 2.1.6 July 23, 2019

--- a/src/LogTarget.php
+++ b/src/LogTarget.php
@@ -59,11 +59,11 @@ class LogTarget extends Target
         foreach ($this->module->panels as $id => $panel) {
             try {
                 $panelData = $panel->save();
-                $data[$id] = Closure\serialize($panelData);
                 if ($id === 'profiling') {
                     $summary['peakMemory'] = $panelData['memory'];
                     $summary['processingTime'] = $panelData['time'];
                 }
+                $data[$id] = Closure\serialize($panelData);
             } catch (\Exception $exception) {
                 $exceptions[$id] = new FlattenException($exception);
             }

--- a/src/Panel.php
+++ b/src/Panel.php
@@ -197,13 +197,33 @@ class Panel extends Component
      * level values. Value 0 means allowing all levels.
      * @param array $categories the message categories to filter by. If empty, it means all categories are allowed.
      * @param array $except the message categories to exclude. If empty, it means all categories are allowed.
+     * @param bool $stringify Convert non-string (such as closures) to strings
      * @return array the filtered messages.
      * @since 2.1.4
      * @see \yii\log\Target::filterMessages()
      */
-    protected function getLogMessages($levels = 0, $categories = [], $except = [])
+    protected function getLogMessages($levels = 0, $categories = [], $except = [], $stringify = false)
     {
         $target = $this->module->logTarget;
-        return $target->filterMessages($target->messages, $levels, $categories, $except);
+        $messages = $target->filterMessages($target->messages, $levels, $categories, $except);
+
+        if (!$stringify) {
+            return $messages;
+        }
+
+        foreach ($messages as &$message) {
+            if (!isset($message[0]) || is_string($message[0])) {
+                continue;
+            }
+
+            // exceptions may not be serializable if in the call stack somewhere is a Closure
+            if ($message[0] instanceof \Throwable || $message[0] instanceof \Exception) {
+                $message[0] = (string) $message[0];
+            } else {
+                $message[0] = VarDumper::export($message[0]);
+            }
+        }
+
+        return $messages;
     }
 }

--- a/src/panels/DumpPanel.php
+++ b/src/panels/DumpPanel.php
@@ -91,11 +91,19 @@ class DumpPanel extends Panel
 
         $messages = $this->getLogMessages(Logger::LEVEL_TRACE, $this->categories, $except);
 
+        foreach ($messages as &$message) {
+            if (!isset($message[0])) {
+                continue;
+            }
+
+            $message[0] = $this->varDump($message[0]);
+        }
+
         return $messages;
     }
 
     /**
-     * Called by view to format the dumped variable.
+     * Called by `save()` to format the dumped variable.
      *
      * @since 2.1.3
      */

--- a/src/panels/LogPanel.php
+++ b/src/panels/LogPanel.php
@@ -67,7 +67,7 @@ class LogPanel extends Panel
             $except = $this->module->panels['router']->getCategories();
         }
 
-        $messages = $this->getLogMessages(Logger::LEVEL_ERROR | Logger::LEVEL_INFO | Logger::LEVEL_WARNING | Logger::LEVEL_TRACE, [], $except);
+        $messages = $this->getLogMessages(Logger::LEVEL_ERROR | Logger::LEVEL_INFO | Logger::LEVEL_WARNING | Logger::LEVEL_TRACE, [], $except, true);
 
         return ['messages' => $messages];
     }

--- a/src/views/default/panels/dump/detail.php
+++ b/src/views/default/panels/dump/detail.php
@@ -21,7 +21,7 @@ echo GridView::widget([
         [
             'attribute' => 'message',
             'value' => function ($data) use ($panel) {
-                $message = $panel->varDump($data['message']);
+                $message = $data['message'];
 
                 if (!empty($data['trace'])) {
                     $message .= Html::ul($data['trace'], [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes (probably need some more)
| Fixed issues  | #401 

Partial revert of #398, so the log panel will work correctly.  The dump panel will now format the object before it is serialized and save that string instead, which is much safer.