### PR TITLE
Fixes in "Since previous" column's value calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.1.9 under development
 -----------------------
 
-- no changes in this release.
+- Bug #409: Fixed "Since previous" column's value calculation (Ir00man)
 
 
 2.1.8 August 20, 2019

--- a/src/views/default/panels/log/detail.php
+++ b/src/views/default/panels/log/detail.php
@@ -62,24 +62,15 @@ echo GridView::widget([
         [
             'attribute' => 'time_since_previous',
             'value' => static function ($data) {
-                $timeOfPrevious = $data['time_of_previous'] / 1000;
-                if (strpos($timeOfPrevious, '.') === false) {
-                    $timeOfPrevious .= '.0';
-                }
-                $time = $data['time'] / 1000;
-                if (strpos($time, '.') === false) {
-                    $time .= '.0';
-                }
-                $previousDateTime = \DateTime::createFromFormat('U.u', $timeOfPrevious);
-                $thisDateTime = \DateTime::createFromFormat('U.u', $time);
+                $diffInMs = $data['time'] - $data['time_of_previous'];
+                $diffInSeconds = $diffInMs / 1000;
+                $diffInMinutes = $diffInSeconds / 60;
+                $diffInHours = $diffInMinutes / 60;
 
-                $diffInSeconds = ($data['time'] - $data['time_of_previous']) / 1000;
-                $diffInMs = (int) (($diffInSeconds - (int) $diffInSeconds) * 1000);
-
-                $diff = $thisDateTime->diff($previousDateTime);
-                $diffHours = (int) $diff->format('%h');
-                $diffMinutes = (int) $diff->format('%i');
-                $diffSeconds = (int) $diff->format('%s');
+                $diffMs = $diffInMs % 1000;
+                $diffSeconds = $diffInSeconds % 60;
+                $diffMinutes = $diffInMinutes % 60;
+                $diffHours = (int)$diffInHours;
 
                 $formattedDiff = [];
                 if ($diffHours > 0) {
@@ -91,7 +82,7 @@ echo GridView::widget([
                 if ($diffSeconds > 0) {
                     $formattedDiff[] = $diffSeconds . 's';
                 }
-                $formattedDiff[] = $diffInMs . 'ms';
+                $formattedDiff[] = $diffMs . 'ms';
                 $formattedDiff = implode('&nbsp;', $formattedDiff);
 
                 $previousBtnOptions = [


### PR DESCRIPTION
Due to differences in how DateInterval::format() works in different PHP versions we need to replace it for simple math.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #409