### PR TITLE
Fix #202: add buttons for navigation between requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.1.11 under development
 ------------------------
 
-- no changes in this release.
+- Enh #202: add buttons for navigation between requests (zhukovra)
 
 
 2.1.10 October 22, 2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.1.11 under development
 ------------------------
 
-- Enh #202: add buttons for navigation between requests (zhukovra)
+- Enh #202: Add buttons for navigation between requests (zhukovra)
 - Bug #423: Fix duplicated toolbar when loading the iframe from a different origin (My6UoT9, samdark)
 - Bug #329: Fix logging AJAX request if URL has domain (zhukovra)
 - Bug #325: Remove staled data files i.e. files that are not in the current index file (zhukovra)

--- a/src/views/default/view.php
+++ b/src/views/default/view.php
@@ -2,6 +2,7 @@
 
 use yii\helpers\Html;
 use yii\helpers\Url;
+use yii\debug\widgets\NavigationButton;
 
 /* @var $this \yii\web\View */
 /* @var $summary array */
@@ -78,24 +79,12 @@ $this->title = 'Yii Debugger';
 
                     ?>
                     <div class="btn-group btn-group-sm" role="group">
-                        <?php
-                        $previousTag = $nextTag = null;
-                        $previousRoute = $nextRoute = '';
-                        $manifestKeys = array_keys($manifest);
-                        $currentTagIndex = array_search($tag, $manifestKeys, true);
-
-                        if ($currentTagIndex >= 1) {
-                            $previousTag = $manifestKeys[$currentTagIndex - 1];
-                            $previousRoute = ['view', 'panel' => $activePanel->id, 'tag' => $previousTag];
-                        }
-
-                        if ((count($manifestKeys) - $currentTagIndex) > 1) {
-                            $nextTag = $manifestKeys[$currentTagIndex + 1];
-                            $nextRoute = ['view', 'panel' => $activePanel->id, 'tag' => $nextTag];
-                        }
-                        ?>
-                        <?=Html::a('Prev', $previousRoute, ['class' => ['btn', 'btn-light', $previousTag ?: 'disabled']])?>
-                        <?=Html::a('Next', $nextRoute, ['class' => ['btn', 'btn-light', $nextTag ?: 'disabled']])?>
+                        <?= NavigationButton::widget(
+                            ['manifest' => $manifest, 'tag' => $tag, 'panel' => $activePanel, 'button' => 'Prev']
+                        ) ?>
+                        <?= NavigationButton::widget(
+                            ['manifest' => $manifest, 'tag' => $tag, 'panel' => $activePanel, 'button' => 'Next']
+                        ) ?>
                     </div>
                     <div class="btn-group btn-group-sm" role="group">
                         <?=Html::a('All', ['index'], ['class' => ['btn', 'btn-light']]);?>

--- a/src/views/default/view.php
+++ b/src/views/default/view.php
@@ -78,6 +78,26 @@ $this->title = 'Yii Debugger';
 
                     ?>
                     <div class="btn-group btn-group-sm" role="group">
+                        <?php
+                        $previousTag = $nextTag = null;
+                        $previousRoute = $nextRoute = '';
+                        $manifestKeys = array_keys($manifest);
+                        $currentTagIndex = array_search($tag, $manifestKeys, true);
+
+                        if ($currentTagIndex >= 1) {
+                            $previousTag = $manifestKeys[$currentTagIndex - 1];
+                            $previousRoute = ['view', 'panel' => $activePanel->id, 'tag' => $previousTag];
+                        }
+
+                        if ((count($manifestKeys) - $currentTagIndex) > 1) {
+                            $nextTag = $manifestKeys[$currentTagIndex + 1];
+                            $nextRoute = ['view', 'panel' => $activePanel->id, 'tag' => $nextTag];
+                        }
+                        ?>
+                        <?=Html::a('Prev', $previousRoute, ['class' => ['btn', 'btn-light', $previousTag ?: 'disabled']])?>
+                        <?=Html::a('Next', $nextRoute, ['class' => ['btn', 'btn-light', $nextTag ?: 'disabled']])?>
+                    </div>
+                    <div class="btn-group btn-group-sm" role="group">
                         <?=Html::a('All', ['index'], ['class' => ['btn', 'btn-light']]);?>
                         <?=Html::a('Latest', ['view', 'panel' => $activePanel->id], ['class' => ['btn', 'btn-light']]);?>
                         <div class="btn-group btn-group-sm" role="group">

--- a/src/widgets/NavigationButton.php
+++ b/src/widgets/NavigationButton.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace yii\debug\widgets;
+
+use yii\base\Widget;
+use yii\debug\Panel;
+use yii\helpers\Html;
+
+/**
+ * Render button for navigation to previous or next request in debug panel
+ */
+class NavigationButton extends Widget
+{
+    /** @var array */
+    public $manifest;
+
+    /** @var string */
+    public $tag;
+
+    /** @var string */
+    public $button;
+
+    /** @var Panel */
+    public $panel;
+
+    /** @var string */
+    private $firstTag;
+
+    /** @var string */
+    private $lastTag;
+
+    /** @var int */
+    private $currentTagIndex;
+
+    /**
+     * @inheritDoc
+     */
+    public function beforeRun()
+    {
+        $manifestKeys = array_keys($this->manifest);
+        $this->firstTag = reset($manifestKeys);
+        $this->lastTag = end($manifestKeys);
+        $this->currentTagIndex = array_search($this->tag, $manifestKeys);
+
+        return parent::beforeRun();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function run()
+    {
+        $method = "render{$this->button}Button";
+
+        return $this->$method();
+    }
+
+    /**
+     * @return string
+     */
+    private function renderPrevButton()
+    {
+        $needLink = $this->tag !== $this->firstTag;
+
+        return Html::a(
+            'Prev',
+            $needLink ? $this->getRoute(-1) : '',
+            ['class' => ['btn', 'btn-light', $needLink ? '' : 'disabled']]
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function renderNextButton()
+    {
+        $needLink = $this->tag !== $this->lastTag;
+
+        return Html::a(
+            'Next',
+            $needLink ? $this->getRoute(1) : '',
+            ['class' => ['btn', 'btn-light', $needLink ? '' : 'disabled']]
+        );
+    }
+
+    /**
+     * @param int $inc Direction
+     * @return array
+     */
+    private function getRoute($inc)
+    {
+        return [
+            'view',
+            'panel' => $this->panel->id,
+            'tag' => array_keys($this->manifest)[$this->currentTagIndex + $inc],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #202 

Single request:
![image](https://user-images.githubusercontent.com/289431/67755314-ff572000-fa48-11e9-8ce8-8c9d2c75a5a5.png)

First active request:
![image](https://user-images.githubusercontent.com/289431/67755335-07af5b00-fa49-11e9-87ea-ab295b34f383.png)

"Middle" active request:
![image](https://user-images.githubusercontent.com/289431/67755357-0f6eff80-fa49-11e9-9d02-ac633812dc96.png)

Last active request:
![image](https://user-images.githubusercontent.com/289431/67755386-1a299480-fa49-11e9-80ff-673e8aedb6aa.png)
