### PR TITLE
Duplicate toolbar bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.1.11 under development
 ------------------------
 
+- Bug #330: Fix duplicated toolbar when loading the iframe from a different origin (My6UoT9, samdark)
 - Bug #329: Fix logging AJAX request if URL has domain (zhukovra)
 - Bug #325: Remove staled data files i.e. files that are not in the current index file (zhukovra)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.1.11 under development
 ------------------------
 
-- Bug #330: Fix duplicated toolbar when loading the iframe from a different origin (My6UoT9, samdark)
+- Bug #423: Fix duplicated toolbar when loading the iframe from a different origin (My6UoT9, samdark)
 - Bug #329: Fix logging AJAX request if URL has domain (zhukovra)
 - Bug #325: Remove staled data files i.e. files that are not in the current index file (zhukovra)
 

--- a/src/views/default/index.php
+++ b/src/views/default/index.php
@@ -175,7 +175,7 @@ $this->title = 'Yii Debugger';
     </div>
 </div>
 <script type="text/javascript">
-    if (window.top === window) {
+    if (window.top == window) {
         document.querySelector('#yii-debug-toolbar').style.display = 'block';
     }
 </script>

--- a/src/views/default/index.php
+++ b/src/views/default/index.php
@@ -175,7 +175,7 @@ $this->title = 'Yii Debugger';
     </div>
 </div>
 <script type="text/javascript">
-    if (!window.frameElement) {
+    if (window.top === window) {
         document.querySelector('#yii-debug-toolbar').style.display = 'block';
     }
 </script>

--- a/src/views/default/view.php
+++ b/src/views/default/view.php
@@ -110,7 +110,7 @@ $this->title = 'Yii Debugger';
     </div>
 </div>
 <script type="text/javascript">
-    if (window.top === window) {
+    if (window.top == window) {
         document.querySelector('#yii-debug-toolbar').style.display = 'block';
     }
 </script>

--- a/src/views/default/view.php
+++ b/src/views/default/view.php
@@ -110,7 +110,7 @@ $this->title = 'Yii Debugger';
     </div>
 </div>
 <script type="text/javascript">
-    if (!window.frameElement) {
+    if (window.top === window) {
         document.querySelector('#yii-debug-toolbar').style.display = 'block';
     }
 </script>


### PR DESCRIPTION
When `document.domain` is set for cross-origin reasons, `window.frameElement` can return `null`.
Comparing `window.top` to `window` is safe, as when both objects are same it is no iframe.

https://developer.mozilla.org/en-US/docs/Web/API/Window/frameElement
https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#Changing_origin

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 
