### PR TITLE
Fixes missing variable link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.1.12 under development
 ------------------------
 
-- Bug #424: Fixes missing variable link (My6UoT9)
+- Bug #424: Fixes missing timeline panel tooltips (My6UoT9)
 
 
 2.1.11 November 05, 2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.1.12 under development
 ------------------------
 
-- no changes in this release.
+- Bug #424: Fixes missing variable link (My6UoT9)
 
 
 2.1.11 November 05, 2019

--- a/src/assets/js/timeline.js
+++ b/src/assets/js/timeline.js
@@ -37,7 +37,7 @@
             for (var i = 0, len = links.length; i < len; i++) {
                 new Tooltip(links[i]);
 
-                on(link, 'show.bs.tooltip', function() {
+                on(links[i], 'show.bs.tooltip', function() {
                     if (this.hasAttribute('data-memory')) {
                         var data = this.dataset.memory;
                         self.options.$memory.textContent = data[0];


### PR DESCRIPTION
In earlier version the code was using foreach which created the link variable, current code uses a for loop.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 
