### PR TITLE
Fix import yii\helpers\Html in DumpPanel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.1.13 under development
 ------------------------
 
-- no changes in this release.
+- Fix #427: Fix missing import yii\helpers\Html in DumpPanel (zhukovra)
 
 
 2.1.12 November 19, 2019

--- a/src/panels/DumpPanel.php
+++ b/src/panels/DumpPanel.php
@@ -8,6 +8,7 @@
 namespace yii\debug\panels;
 
 use Yii;
+use yii\helpers\Html;
 use yii\log\Logger;
 use yii\debug\models\search\Log;
 use yii\debug\Panel;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 

I don't know how it was working without importing class:
https://github.com/yiisoft/yii2-debug/blob/3faaa0d6a8ee7592f23f0962496773d1d9ead0b0/src/panels/DumpPanel.php#L120

Can be tested with:
```php
        $panel = new DumpPanel([
            'highlight' => false,
        ]);
        $panel->varDump('');
```
but I'm not sure that the tests needs to be written for that.