### PR TITLE
Changed return statement to false in init

### DIFF
--- a/src/panels/UserPanel.php
+++ b/src/panels/UserPanel.php
@@ -81,7 +81,7 @@ class UserPanel extends Panel
     public function init()
     {
         if (!$this->isEnabled() || $this->getUser()->isGuest) {
-            return;
+            return false;
         }
 
         $this->userSwitch = new UserSwitch(['userComponent' => $this->userComponent]);


### PR DESCRIPTION
Currently if you want to extend UserPanel and implement a custom init method UserPanel::init() blocks the execution if the user is not logged or panel is disabled without being able to check if UserPanel::init is returning true or false.

By changing the return statement to 'false' you can check where it is passing or not without blocking the execution.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
