### PR TITLE
Initiating controllers take 3

### DIFF
--- a/tests/router/ActionRoutesTest.php
+++ b/tests/router/ActionRoutesTest.php
@@ -44,6 +44,16 @@ class ActionRoutesTest extends TestCase
                     'rule' => '<controller>/<action>',
                     'count' => 1,
                 ],
+                'yiiunit\debug\router\controllers\RedirectController::actionOnly()' => [
+                    'route' => 'redirect/only',
+                    'rule' => '<controller>/<action>',
+                    'count' => 1,
+                ],
+                'yiiunit\debug\router\controllers\RedirectController::actions()[test] => yii\web\ErrorAction' => [
+                    'route' => 'redirect/test',
+                    'rule' => '<controller>/<action>',
+                    'count' => 1,
+                ],
                 'yiiunit\debug\router\controllers\RestController::actions()[create] => yii\rest\CreateAction' => [
                     'route' => 'rest/create',
                     'rule' => '<controller>/<action>',

--- a/tests/router/ActionRoutesTest.php
+++ b/tests/router/ActionRoutesTest.php
@@ -44,45 +44,25 @@ class ActionRoutesTest extends TestCase
                     'rule' => '<controller>/<action>',
                     'count' => 1,
                 ],
+                'yiiunit\debug\router\controllers\BadController::actions()' => [
+                    'route' => 'bad/[external-action]',
+                    'rule' => null,
+                    'count' => 0,
+                ],
                 'yiiunit\debug\router\controllers\RedirectController::actionOnly()' => [
                     'route' => 'redirect/only',
                     'rule' => '<controller>/<action>',
                     'count' => 1,
                 ],
-                'yiiunit\debug\router\controllers\RedirectController::actions()[test] => yii\web\ErrorAction' => [
-                    'route' => 'redirect/test',
-                    'rule' => '<controller>/<action>',
-                    'count' => 1,
+                'yiiunit\debug\router\controllers\RedirectController::actions()' => [
+                    'route' => 'redirect/[external-action]',
+                    'rule' => null,
+                    'count' => 0,
                 ],
-                'yiiunit\debug\router\controllers\RestController::actions()[create] => yii\rest\CreateAction' => [
-                    'route' => 'rest/create',
-                    'rule' => '<controller>/<action>',
-                    'count' => 1,
-                ],
-                'yiiunit\debug\router\controllers\RestController::actions()[delete] => yii\rest\DeleteAction' => [
-                    'route' => 'rest/delete',
-                    'rule' => '<controller>/<action>',
-                    'count' => 1,
-                ],
-                'yiiunit\debug\router\controllers\RestController::actions()[index] => yii\rest\IndexAction' => [
-                    'route' => 'rest/index',
-                    'rule' => '<controller>/<action>',
-                    'count' => 1,
-                ],
-                'yiiunit\debug\router\controllers\RestController::actions()[options] => yii\rest\OptionsAction' => [
-                    'route' => 'rest/options',
-                    'rule' => '<controller>/<action>',
-                    'count' => 1,
-                ],
-                'yiiunit\debug\router\controllers\RestController::actions()[update] => yii\rest\UpdateAction' => [
-                    'route' => 'rest/update',
-                    'rule' => '<controller>/<action>',
-                    'count' => 1,
-                ],
-                'yiiunit\debug\router\controllers\RestController::actions()[view] => yii\rest\ViewAction' => [
-                    'route' => 'rest/view',
-                    'rule' => '<controller>/<action>',
-                    'count' => 1,
+                'yiiunit\debug\router\controllers\RestController::actions()' => [
+                    'route' => 'rest/[external-action]',
+                    'rule' => null,
+                    'count' => 0,
                 ],
                 'yiiunit\debug\router\controllers\WebController::actionFirst()' => [
                     'route' => 'web/first',
@@ -94,20 +74,20 @@ class ActionRoutesTest extends TestCase
                     'rule' => '<controller>/<action>',
                     'count' => 1,
                 ],
-                'yiiunit\debug\router\controllers\WebController::actions()[errorStraight] => yii\web\ErrorAction' => [
-                    'route' => 'web/error-straight',
-                    'rule' => '<controller>/<action>',
-                    'count' => 1,
-                ],
-                'yiiunit\debug\router\controllers\WebController::actions()[error] => yii\web\ErrorAction' => [
-                    'route' => 'web/error',
-                    'rule' => '<controller>/<action>',
-                    'count' => 1,
+                'yiiunit\debug\router\controllers\WebController::actions()' => [
+                    'route' => 'web/[external-action]',
+                    'rule' => null,
+                    'count' => 0,
                 ],
                 'yiiunit\debug\router\module\controllers\ModuleWebController::actionInside()' => [
                     'route' => 'admin/module-web/inside',
                     'rule' => 'admin/inside',
                     'count' => 2,
+                ],
+                'yiiunit\debug\router\module\controllers\ModuleWebController::actions()' => [
+                    'route' => 'admin/module-web/[external-action]',
+                    'rule' => null,
+                    'count' => 0,
                 ],
             ],
             $routes->routes

--- a/tests/router/controllers/RedirectController.php
+++ b/tests/router/controllers/RedirectController.php
@@ -4,11 +4,11 @@ namespace yiiunit\debug\router\controllers;
 
 use yii\web\Controller;
 
-class BadController extends Controller
+class RedirectController extends Controller
 {
     public function init()
     {
-        throw new \Exception('Simulates problem with controller when initialing');
+        \Yii::$app->response->redirect('web/first');
     }
 
     public function actionOnly()
@@ -18,6 +18,6 @@ class BadController extends Controller
 
     public function actions()
     {
-        return ['test' => 'Something not important'];
+        return ['test' => 'yii\web\ErrorAction'];
     }
 }


### PR DESCRIPTION
Ok, last try. This time controllers are not initialized at all in order to avoid calling any method to prevent any additional extra stuff that can be done there. Unfortunately this makes scanning `actions()` not possible (at least I cannot find a way to do it without using some extra code parsers or something similar) so I'm just leaving it mentioned.