### PR TITLE
Enh #454: Add `yii\debug\panels\DbPanel::$dbEventNames` that allows s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.1.17 under development
 ------------------------
 
-- no changes in this release.
+- Enh #454: Add `yii\debug\panels\DbPanel::$dbEventNames` that allows specifying event names used to get profile logs for db panel (atiline)
 
 
 2.1.16 December 23, 2020

--- a/src/panels/DbPanel.php
+++ b/src/panels/DbPanel.php
@@ -59,7 +59,11 @@ class DbPanel extends Panel
      * @var array current database request timings
      */
     private $_timings;
-
+    /**
+     * @var array of event names used to get profile logs.
+     * @since 2.1.17
+     */
+    public $dbEventNames = ['yii\db\Command::query', 'yii\db\Command::execute'];
 
     /**
      * {@inheritdoc}
@@ -154,13 +158,12 @@ class DbPanel extends Panel
     }
 
     /**
-     * Returns all profile logs of the current request for this panel. It includes categories such as:
-     * 'yii\db\Command::query', 'yii\db\Command::execute'.
+     * Returns all profile logs of the current request for this panel. It includes categories specified in $this->dbEventNames property.
      * @return array
      */
     public function getProfileLogs()
     {
-        return $this->getLogMessages(Logger::LEVEL_PROFILE, ['yii\db\Command::query', 'yii\db\Command::execute']);
+        return $this->getLogMessages(Logger::LEVEL_PROFILE, $this->dbEventNames);
     }
 
     /**


### PR DESCRIPTION
…pecifying event names used to get profile logs for db panel

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #454
