### PR TITLE
Add CIDR support for allowedIPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.1.18 under development
 ------------------------
 
-- no changes in this release.
+- Enh #458: Added CIDR support for allowedIPs (rhertogh)
 
 
 2.1.17 May 05, 2021

--- a/src/Module.php
+++ b/src/Module.php
@@ -30,8 +30,10 @@ class Module extends \yii\base\Module implements BootstrapInterface
 
     /**
      * @var array the list of IPs that are allowed to access this module.
-     * Each array element represents a single IP filter which can be either an IP address
-     * or an address with wildcard (e.g. 192.168.0.*) to represent a network segment.
+     * Each array element represents a single IP filter which can be either:
+     * - an IP address (e.g. 1.2.3.4),
+     * - an address with wildcard (e.g. 192.168.0.*) to represent a network segment
+     * - a CIDR range (e.g. 172.16.0.0/12) (available since version 2.1.18).
      * The default value is `['127.0.0.1', '::1']`, which means the module can only be accessed
      * by localhost.
      */

--- a/src/Module.php
+++ b/src/Module.php
@@ -11,6 +11,7 @@ use Yii;
 use yii\base\Application;
 use yii\base\BootstrapInterface;
 use yii\helpers\Html;
+use yii\helpers\IpHelper;
 use yii\helpers\Json;
 use yii\helpers\Url;
 use yii\web\ForbiddenHttpException;
@@ -406,7 +407,17 @@ class Module extends \yii\base\Module implements BootstrapInterface
 
         $ip = Yii::$app->getRequest()->getUserIP();
         foreach ($this->allowedIPs as $filter) {
-            if ($filter === '*' || $filter === $ip || (($pos = strpos($filter, '*')) !== false && !strncmp($ip, $filter, $pos))) {
+            if ($filter === '*'
+                || $filter === $ip
+                || (
+                    ($pos = strpos($filter, '*')) !== false
+                    && !strncmp($ip, $filter, $pos)
+                )
+                || (
+                    strpos($filter, '/') !== false
+                    && IpHelper::inRange($ip, $filter)
+                )
+            ) {
                 $allowed = true;
                 break;
             }

--- a/tests/ModuleTest.php
+++ b/tests/ModuleTest.php
@@ -49,6 +49,31 @@ class ModuleTest extends TestCase
                 '10.20.40.40',
                 false
             ],
+            [
+                ['172.16.0.0/12'],
+                '172.15.1.2', // "below" CIDR range
+                false
+            ],
+            [
+                ['172.16.0.0/12'],
+                '172.16.0.0', // in CIDR range
+                true
+            ],
+            [
+                ['172.16.0.0/12'],
+                '172.22.33.44', // in CIDR range
+                true
+            ],
+            [
+                ['172.16.0.0/12'],
+                '172.31.255.255', // in CIDR range
+                true
+            ],
+            [
+                ['172.16.0.0/12'],
+                '172.32.1.2',  // "above" CIDR range
+                false
+            ],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -

This PR adds support for CIDR ranges in allowedIPs, which is especially useful for docker (which uses class B ranges by default).
