### PR TITLE
Using symfonymailer instead of swiftmailer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "opis/closure": "^3.3"
     },
     "require-dev": {
-        "yiisoft/yii2-swiftmailer": "*",
+        "yiisoft/yii2-symfonymailer": "*",
         "yiisoft/yii2-coding-standards": "~2.0",
         "cweagans/composer-patches": "^1.7",
         "phpunit/phpunit": "4.8.34"


### PR DESCRIPTION
Replace swiftmailer with symfonymailer
There is a reference to swiftmailer inside MailPanel.php but I believe that has to stay for BC. I assume symfonymailer does not required any conditional code so I have not edited this. Simply change really ! LOL 
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #467 
