### PR TITLE
Fix inability to change LogTarget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,7 @@
 Yii Framework 2 debug extension Change Log
 ==========================================
 
-2.1.20 under development
-------------------------
-
-- no changes in this release.
-
-
-2.1.19 February 11, 2020
+2.1.19 under development
 ------------------------
 
 - Enh #469: Add option to change default LogTarget (laxity7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 Yii Framework 2 debug extension Change Log
 ==========================================
 
-2.1.19 under development
+2.1.20 under development
 ------------------------
 
 - no changes in this release.
+
+
+2.1.19 February 11, 2020
+------------------------
+
+- Enh #469: Add option to change default LogTarget (laxity7)
 
 
 2.1.18 August 09, 2021

--- a/src/Module.php
+++ b/src/Module.php
@@ -62,7 +62,7 @@ class Module extends \yii\base\Module implements BootstrapInterface
     /**
      * @var LogTarget
      */
-    public $logTarget;
+    public $logTarget = 'yii\debug\LogTarget';
     /**
      * @var array|Panel[] list of debug panels. The array keys are the panel IDs, and values are the corresponding
      * panel class names or configuration arrays. This will be merged with [[corePanels()]].
@@ -265,7 +265,7 @@ class Module extends \yii\base\Module implements BootstrapInterface
     public function bootstrap($app)
     {
         /* @var $app \yii\base\Application */
-        $this->logTarget = $app->getLog()->targets['debug'] = new LogTarget($this);
+        $this->logTarget = $app->getLog()->targets['debug'] = Yii::createObject($this->logTarget, [$this]);
 
         // delay attaching event handler to the view component after it is fully configured
         $app->on(Application::EVENT_BEFORE_REQUEST, function () use ($app) {


### PR DESCRIPTION
Added the ability to change logTarget, now it's hard code class.

```php
$config['modules']['debug'] = [
    'class' => 'yii\debug\Module',
    'allowedIPs' => ['*'],
    'logTarget' => \common\components\DebugLogTarget::class // nothing affects
];
```

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | none
