### PR TITLE
Fixes 8.1 issue: class_exists with null value will error

### DIFF
--- a/src/panels/UserPanel.php
+++ b/src/panels/UserPanel.php
@@ -88,7 +88,7 @@ class UserPanel extends Panel
         $this->addAccessRules();
 
         if (!is_object($this->filterModel)
-            && !is_null($this->filterModel)
+            && $this->filterModel !== null
             && class_exists($this->filterModel)
             && in_array('yii\debug\models\search\UserSearchInterface', class_implements($this->filterModel), true)
         ) {

--- a/src/panels/UserPanel.php
+++ b/src/panels/UserPanel.php
@@ -88,6 +88,7 @@ class UserPanel extends Panel
         $this->addAccessRules();
 
         if (!is_object($this->filterModel)
+            && !is_null($this->filterModel)
             && class_exists($this->filterModel)
             && in_array('yii\debug\models\search\UserSearchInterface', class_implements($this->filterModel), true)
         ) {


### PR DESCRIPTION
If the UserPanel class member variable `$this->filterModel` is NULL, php 8.1 will complain and throw a deprecation error. 

I am adding an is_null() check before the class_exists call to fix this

```
PHP Deprecated Warning – yii\base\ErrorException
class_exists(): Passing null to parameter #1 ($class) of type string is deprecated
```

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #473 
