### PR TITLE
fix error under PHP v8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Yii Framework 2 debug extension Change Log
 
 - Enh #469: Add option to change default LogTarget (laxity7)
 - Bug #466: Remove opis\closure dependency for PHP 8.1 compatibility. Closures in logs still working (sartor)
-
+- Bug #475: Fix PHP Deprecated Warning – yii\base\ErrorException resulting from passing null class string to class_exists() under PHP 8.1 (themikem)  
 
 2.1.18 August 09, 2021
 ----------------------

--- a/src/panels/UserPanel.php
+++ b/src/panels/UserPanel.php
@@ -87,7 +87,8 @@ class UserPanel extends Panel
         $this->userSwitch = new UserSwitch(['userComponent' => $this->userComponent]);
         $this->addAccessRules();
 
-        if (is_string($this->filterModel)
+        if (!empty($this->filterModel)
+            && is_string($this->filterModel)
             && class_exists($this->filterModel)
             && in_array('yii\debug\models\search\UserSearchInterface', class_implements($this->filterModel), true)
         ) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 

Fixes the error:
PHP Deprecated Warning – yii\base\ErrorException
class_exists(): Passing null to parameter #1 ($class) of type string is deprecated