### PR TITLE
Fix PHP 8.1 warning (implicit conversion from float to int loses precision)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 debug extension Change Log
 
 - Enh #469: Add option to change default LogTarget (laxity7)
 - Bug #466: Remove opis\closure dependency for PHP 8.1 compatibility. Closures in logs still working (sartor)
+- Bug #470: Fix PHP 8.1 warnings about implicit conversion from float to int loses precision (mishamosher)
 
 
 2.1.18 August 09, 2021

--- a/src/views/default/panels/db/detail.php
+++ b/src/views/default/panels/db/detail.php
@@ -52,7 +52,7 @@ echo GridView::widget([
                 $timeInSeconds = $data['timestamp'] / 1000;
                 $millisecondsDiff = (int)(($timeInSeconds - (int)$timeInSeconds) * 1000);
 
-                return date('H:i:s.', $timeInSeconds) . sprintf('%03d', $millisecondsDiff);
+                return date('H:i:s.', (int)$timeInSeconds) . sprintf('%03d', $millisecondsDiff);
             },
             'headerOptions' => [
                 'class' => 'sort-numerical'

--- a/src/views/default/panels/log/detail.php
+++ b/src/views/default/panels/log/detail.php
@@ -69,13 +69,13 @@ echo GridView::widget([
             'attribute' => 'time_since_previous',
             'value' => static function ($data) {
                 $diffInMs = $data['time'] - $data['time_of_previous'];
-                $diffInSeconds = (int)$diffInMs / 1000;
-                $diffInMinutes = (int)$diffInSeconds / 60;
-                $diffInHours = (int)$diffInMinutes / 60;
+                $diffInSeconds = $diffInMs / 1000;
+                $diffInMinutes = $diffInSeconds / 60;
+                $diffInHours = $diffInMinutes / 60;
 
-                $diffMs = $diffInMs % 1000;
-                $diffSeconds = $diffInSeconds % 60;
-                $diffMinutes = $diffInMinutes % 60;
+                $diffMs = (int)$diffInMs % 1000;
+                $diffSeconds = (int)$diffInSeconds % 60;
+                $diffMinutes = (int)$diffInMinutes % 60;
                 $diffHours = (int)$diffInHours;
 
                 $formattedDiff = [];

--- a/src/views/default/panels/profile/detail.php
+++ b/src/views/default/panels/profile/detail.php
@@ -47,7 +47,7 @@ echo GridView::widget([
                 $timeInSeconds = $data['timestamp'] / 1000;
                 $millisecondsDiff = (int)(($timeInSeconds - (int)$timeInSeconds) * 1000);
 
-                return date('H:i:s.', $timeInSeconds) . sprintf('%03d', $millisecondsDiff);
+                return date('H:i:s.', (int)$timeInSeconds) . sprintf('%03d', $millisecondsDiff);
             },
             'headerOptions' => [
                 'class' => 'sort-numerical'


### PR DESCRIPTION
I've been unable to open the logs, profiling, and database panels on PHP 8.1, which greet me with a deprecation notice:

![GH_YII2_DEBUG](https://user-images.githubusercontent.com/3683227/155741220-80dc158d-2e3c-4e87-b245-865450751226.png)

This PR intends to resolve such issue.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #470 
