### PR TITLE
Fix #481: only init logTarget if it's not already

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 debug extension Change Log
 ------------------------
 
 - Bug #461: Do not crash on empty panel data (przepompownia)
-- Enh #484: Allow logTarget config to be set as either a string, an array with class key, or an LogTarget object (Sarke)
+- Enh #484: Allow `logTarget` config to be set as either a string, an array, or an `LogTarget` object (Sarke)
 
 
 2.1.19 April 05, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 debug extension Change Log
 ------------------------
 
 - Bug #461: Do not crash on empty panel data (przepompownia)
+- Enh #484: Allow logTarget config to be set as either a string, an array with class key, or an LogTarget object (Sarke)
 
 
 2.1.19 April 05, 2022

--- a/src/Module.php
+++ b/src/Module.php
@@ -60,7 +60,7 @@ class Module extends \yii\base\Module implements BootstrapInterface
      */
     public $controllerNamespace = 'yii\debug\controllers';
     /**
-     * @var LogTarget
+     * @var LogTarget|array|string the logTarget object, or the configuration for creating the logTarget object.
      */
     public $logTarget = 'yii\debug\LogTarget';
     /**
@@ -264,8 +264,16 @@ class Module extends \yii\base\Module implements BootstrapInterface
      */
     public function bootstrap($app)
     {
+        if (is_array($this->logTarget)) {
+            if (!isset($this->logTarget['class'])) {
+                $this->logTarget['class'] = 'yii\debug\LogTarget';
+            }
+            $this->logTarget = Yii::createObject($this->logTarget, [$this]);
+        } elseif (is_string($this->logTarget)) {
+            $this->logTarget = Yii::createObject($this->logTarget, [$this]);
+        }
         /* @var $app \yii\base\Application */
-        $this->logTarget = $app->getLog()->targets['debug'] = Yii::createObject($this->logTarget, [$this]);
+        $app->getLog()->targets['debug'] = $this->logTarget;
 
         // delay attaching event handler to the view component after it is fully configured
         $app->on(Application::EVENT_BEFORE_REQUEST, function () use ($app) {

--- a/tests/ModuleTest.php
+++ b/tests/ModuleTest.php
@@ -180,4 +180,16 @@ HTML
 
         $this->assertEquals('2.0.7', $module->getVersion());
     }
+
+    /**
+     * Test to ensure logTarget can take object as config
+     */
+    public function testLogTargetObject()
+    {
+        $module = new Module('debug');
+        $module->logTarget = new \yii\debug\LogTarget($module);
+        $module->bootstrap(Yii::$app);
+
+        $this->assertInstanceOf('yii\debug\LogTarget', $module->logTarget);
+    }
 }

--- a/tests/ModuleTest.php
+++ b/tests/ModuleTest.php
@@ -96,6 +96,18 @@ class ModuleTest extends TestCase
     }
 
     /**
+     * Test to ensure logTarget can take object as config
+     */
+    public function testLogTargetObject()
+    {
+        $module = new Module('debug');
+        $module->logTarget = new \yii\debug\LogTarget($module);
+        $module->bootstrap(Yii::$app);
+
+        $this->assertInstanceOf('yii\debug\LogTarget', $module->logTarget);
+    }
+
+    /**
      * Test to verify toolbars html
      */
     public function testGetToolbarHtml()
@@ -179,17 +191,5 @@ HTML
         $module = new Module('debug');
 
         $this->assertEquals('2.0.7', $module->getVersion());
-    }
-
-    /**
-     * Test to ensure logTarget can take object as config
-     */
-    public function testLogTargetObject()
-    {
-        $module = new Module('debug');
-        $module->logTarget = new \yii\debug\LogTarget($module);
-        $module->bootstrap(Yii::$app);
-
-        $this->assertInstanceOf('yii\debug\LogTarget', $module->logTarget);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #481

Fixes _slight_ BC break introduced by PR #469.