### PR TITLE
Fix response format after scan routes

### DIFF
--- a/src/panels/RouterPanel.php
+++ b/src/panels/RouterPanel.php
@@ -78,11 +78,13 @@ class RouterPanel extends Panel
      */
     public function getDetail()
     {
-        return Yii::$app->view->render('panels/router/detail', [
+        $view = Yii::$app->view->render('panels/router/detail', [
             'currentRoute' => new CurrentRoute($this->data),
             'routerRules' => new RouterRules(),
             'actionRoutes' => new ActionRoutes(),
         ]);
+        Yii::$app->response->format = Response::FORMAT_HTML;
+        return $view;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 


usecase:

```php
$config = [
    'modules' => [
        'user' => [
            'class' => frontend\modules\user\Module::class,
            'shouldBeActivated' => false,
            'enableLoginByPass' => false,
        ],
    ],
```

```php
<?php

namespace frontend\modules\user;

class Module extends \yii\base\Module
{
    public function init()
    {
        //========I don't know why they reconfigure response like this in current project.
        \Yii::configure(\Yii::$app, [
            'components' => [
                'response' => [
                    'class' => 'yii\web\Response',
                    'format' => \yii\web\Response::FORMAT_JSON,
                    //.....
                ],
                //.....
            ],
        ]);
        //============= if use this,would not tigger the problem
        //\Yii::$app->response->format = \yii\web\Response::FORMAT_JSON;
        parent::init();
    }
}
```

then after scan the ModuleControllers,the response format changed
```
vendor/yiisoft/yii2-debug/src/models/router/ActionRoutes.php:125
if (($child = $module->getModule($id)) === null) {
```

I think it is not a bug,but maybe we could enhance it.

