### PR TITLE
Extend variable masking to requestBody

### DIFF
--- a/src/panels/RequestPanel.php
+++ b/src/panels/RequestPanel.php
@@ -10,6 +10,7 @@ namespace yii\debug\panels;
 use Yii;
 use yii\base\InlineAction;
 use yii\debug\Panel;
+use yii\helpers\ArrayHelper;
 
 /**
  * Debugger panel that collects and displays request data.
@@ -130,16 +131,15 @@ class RequestPanel extends Panel
             'requestBody' => Yii::$app->getRequest()->getRawBody() == '' ? [] : [
                 'Content Type' => Yii::$app->getRequest()->getContentType(),
                 'Raw' => Yii::$app->getRequest()->getRawBody(),
-                'Decoded to Params' => Yii::$app->getRequest()->getBodyParams(),
+                'Decoded' => Yii::$app->getRequest()->getBodyParams(),
             ],
         ];
 
         foreach ($this->displayVars as $name) {
-            $data[trim($name, '_')] = empty($GLOBALS[$name]) ? [] : $this->censorArray($GLOBALS[$name]);
-
+            $data[trim($name, '_')] = empty($GLOBALS[$name]) ? [] : $GLOBALS[$name];
         }
 
-        return $data;
+        return $this->censorArray($data);
     }
 
     /**
@@ -175,9 +175,13 @@ class RequestPanel extends Panel
         if (empty($this->censoredVariableNames) || empty($data)) {
             return $data;
         }
-        foreach ($data as $name => &$value) {
-            if (in_array($name, $this->censoredVariableNames, true)) {
-                $value = $this->censorString;
+        foreach ($this->censoredVariableNames as $var) {
+            $key = ltrim($var, '_');
+            if (ArrayHelper::getValue($data, $key) !== null) {
+                ArrayHelper::setValue($data, $key, $this->censorString);
+                if (strpos($key, 'requestBody') === 0) {
+                    ArrayHelper::setValue($data, 'requestBody.Raw', $this->censorString);
+                }
             }
         }
         return $data;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  |  <!-- comma-separated list of tickets # fixed by the PR, if any -->

**Note**: `Raw` field in `requestBody` will automatically masked if any value masked.

An example in request panel config
~~~
            'request' => [
                'class' => 'yii\debug\panels\RequestPanel',
                'censoredVariableNames' => [
                    '_POST.LoginForm.password',
                    'requestBody.Decoded.LoginForm.password',
                ]
            ]
~~~

![image](https://user-images.githubusercontent.com/3823496/189595237-82da0762-731f-4efa-81ba-0f53105dcb6d.png)
