### PR TITLE
Feature/allow symfonymailer in mail panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Yii Framework 2 debug extension Change Log
 ==========================================
 
+2.1.23 March 14, 2023
+------------------------
+
+- Add yii2-symfonymailer Support in src/panels/MailPanel.php (vansari)
+
 2.1.23 under development
 ------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.1.23 March 14, 2023
 ------------------------
 
-- Add yii2-symfonymailer Support in src/panels/MailPanel.php (vansari)
+- Enh #498: Add yii2-symfonymailer Support in src/panels/MailPanel.php (vansari)
 
 2.1.23 under development
 ------------------------

--- a/src/panels/MailPanel.php
+++ b/src/panels/MailPanel.php
@@ -13,6 +13,7 @@ use yii\debug\models\search\Mail;
 use yii\debug\Panel;
 use yii\helpers\FileHelper;
 use yii\mail\BaseMailer;
+use yii\mail\MessageInterface;
 
 /**
  * Debugger panel that collects and displays the generated emails.
@@ -45,7 +46,7 @@ class MailPanel extends Panel
         Event::on('yii\mail\BaseMailer', BaseMailer::EVENT_AFTER_SEND, function ($event) {
             /* @var $event \yii\mail\MailEvent */
             $message = $event->message;
-            /* @var $message \yii\mail\MessageInterface */
+            /* @var $message MessageInterface */
             $messageData = [
                 'isSuccessful' => $event->isSuccessful,
                 'from' => $this->convertParams($message->getFrom()),
@@ -57,30 +58,7 @@ class MailPanel extends Panel
                 'charset' => $message->getCharset(),
             ];
 
-            // add more information when message is a SwiftMailer message
-            if ($message instanceof \yii\swiftmailer\Message) {
-                /* @var $swiftMessage \Swift_Message */
-                $swiftMessage = $message->getSwiftMessage();
-
-                $body = $swiftMessage->getBody();
-                if (empty($body)) {
-                    $parts = $swiftMessage->getChildren();
-                    foreach ($parts as $part) {
-                        if (!($part instanceof \Swift_Mime_Attachment)) {
-                            /* @var $part \Swift_Mime_MimePart */
-                            if ($part->getContentType() === 'text/plain') {
-                                $messageData['charset'] = $part->getCharset();
-                                $body = $part->getBody();
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                $messageData['body'] = $body;
-                $messageData['time'] = $swiftMessage->getDate();
-                $messageData['headers'] = $swiftMessage->getHeaders();
-            }
+            $this->addMoreInformation($message, $messageData);
 
             // store message as file
             $fileName = $event->sender->generateMessageFileName();
@@ -162,5 +140,61 @@ class MailPanel extends Panel
         }
 
         return $attr;
+    }
+
+    /**
+     * @param MessageInterface $message
+     * @param array $messageData
+     */
+    private function addMoreInformation(MessageInterface $message, array &$messageData)
+    {
+        // add more information when message is a SwiftMailer message
+        if ($message instanceof \yii\swiftmailer\Message) {
+            $this->addMoreInformationFromSwiftMailer($message, $messageData);
+        } elseif ($message instanceof \yii\symfonymailer\Message) {
+            $this->addMoreInformationFromSymfonyMailer($message, $messageData);
+        }
+    }
+
+    private function addMoreInformationFromSwiftMailer(MessageInterface $message, array &$messageData)
+    {
+        /* @var $swiftMessage \Swift_Message */
+        $swiftMessage = $message->getSwiftMessage();
+
+        $body = $swiftMessage->getBody();
+        if (empty($body)) {
+            $parts = $swiftMessage->getChildren();
+            foreach ($parts as $part) {
+                if (!($part instanceof \Swift_Mime_Attachment)) {
+                    /* @var $part \Swift_Mime_MimePart */
+                    if ($part->getContentType() === 'text/plain') {
+                        $messageData['charset'] = $part->getCharset();
+                        $body = $part->getBody();
+                        break;
+                    }
+                }
+            }
+        }
+
+        $messageData['body'] = $body;
+        $messageData['time'] = $swiftMessage->getDate();
+        $messageData['headers'] = $swiftMessage->getHeaders();
+    }
+
+    private function addMoreInformationFromSymfonyMailer(MessageInterface $message, array &$messageData)
+    {
+        /** @var \Symfony\Component\Mime\Email $symfonyMessage */
+        $symfonyMessage = $message->getSymfonyEmail();
+
+        $part = $symfonyMessage->getBody();
+        $body = null;
+        if ($part instanceof \Symfony\Component\Mime\Part\TextPart && 'plain' === $part->getMediaSubtype()) {
+            $messageData['charset'] = $part->asDebugString();
+            $body = $part->getBody();
+        }
+
+        $messageData['body'] = $body;
+        $messageData['headers'] = $part->getPreparedHeaders();
+        $messageData['time'] = $symfonyMessage->getDate();
     }
 }

--- a/src/panels/MailPanel.php
+++ b/src/panels/MailPanel.php
@@ -186,6 +186,7 @@ class MailPanel extends Panel
         /** @var \Symfony\Component\Mime\Email $symfonyMessage */
         $symfonyMessage = $message->getSymfonyEmail();
 
+        /** @var \Symfony\Component\Mime\Part\AbstractPart $part */
         $part = $symfonyMessage->getBody();
         $body = null;
         if ($part instanceof \Symfony\Component\Mime\Part\TextPart && 'plain' === $part->getMediaSubtype()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

The swiftmailer package is abadoned and it is suggested to be replaced with symfony/mailer which can be done with yii2-symfonymailer. 

In this extension you can get extra data from the mail if you use the swiftmailer but not if you use the suggested package yii2-symfonymailer.

This Merge Request will add the support to get the extra data from the symfonymailer message. It should not breaking anything if the symfonymailer is not installed and used.

It would be nice to unit test this but it isn't possible with this setup. If you have any idea how I can test it please let me know.