### PR TITLE
Reduce db panel warnings for "critical query threshold" and "excessive callers"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.1.24 under development
 ------------------------
 
-- no changes in this release.
+- Bug #504: Reduced db panel warnings for "critical query threshold" and "excessive callers" (rhertogh)
 
 
 2.1.23 May 22, 2023

--- a/src/views/default/index.php
+++ b/src/views/default/index.php
@@ -51,16 +51,6 @@ $this->title = 'Yii Debugger';
                         return ['class' => 'table-danger'];
                     }
 
-                    if (
-                        $hasDbPanel
-                        && (
-                            $this->context->module->panels['db']->isQueryCountCritical($model['sqlCount'])
-                            || !empty($model['excessiveCallersCount'])
-                        )
-                    ) {
-                        return ['class' => 'table-danger'];
-                    }
-
                     return [];
                 },
                 'pager' => [
@@ -119,22 +109,19 @@ $this->title = 'Yii Debugger';
                             $dbPanel = $this->context->module->panels['db'];
 
                             $title = "Executed {$data['sqlCount']} database queries.";
-                            $hasError = false;
+                            $warning = '';
                             if ($dbPanel->isQueryCountCritical($data['sqlCount'])) {
-                                $title .= ' &#10;Too many queries. Allowed count is ' . $dbPanel->criticalQueryThreshold;
-                                $hasError = true;
+                                $warning .= 'Too many queries. Allowed count is ' . $dbPanel->criticalQueryThreshold;
                             }
                             if (!empty($data['excessiveCallersCount'])) {
-                                $title .= ' &#10;' . $data['excessiveCallersCount'] . ' '
+                                $warning .= ($warning ? ' &#10;' : '') . $data['excessiveCallersCount'] . ' '
                                     . ($data['excessiveCallersCount'] == 1 ? 'caller is' : 'callers are')
                                     . ' making too many calls.';
-                                $hasError = true;
                             }
 
-                            if ($hasError) {
-                                $content = Html::tag('b', $data['sqlCount']) . ' ' . Html::tag('span', '&#x26a0;');
-                            } else {
-                                $content = $data['sqlCount'];
+                            $content = $data['sqlCount'];
+                            if ($warning) {
+                                $content .= ' <span title="' . $warning . '">&#x26a0;</span>';
                             }
 
                             return '<a href="' . Url::to(['view', 'panel' => 'db', 'tag' => $data['tag']]) .'"

--- a/src/views/default/panels/db/summary.php
+++ b/src/views/default/panels/db/summary.php
@@ -5,28 +5,26 @@
 /* @var $excessiveCallerCount int */
 
 $title = "Executed $queryCount database queries which took $queryTime.";
-$hasError = false;
+$warning = '';
 
 if ($queryCount >= $panel->criticalQueryThreshold) {
-    $title .= " &#10;Too many queries, allowed count is {$panel->criticalQueryThreshold}.";
-    $hasError = true;
+    $warning .= "Too many queries, allowed count is {$panel->criticalQueryThreshold}.";
 }
 if ($excessiveCallerCount) {
-    $title .= ' &#10;' . $excessiveCallerCount . ' '
+    $warning .= ($warning ? ' &#10;' : '') . $excessiveCallerCount . ' '
         . ($excessiveCallerCount == 1 ? 'caller is' : 'callers are')
         .   ' making too many calls.';
-    $hasError = true;
 }
 ?>
 <?php if ($queryCount): ?>
     <div class="yii-debug-toolbar__block">
-        <a href="<?= $panel->getUrl() ?>"
-           title="<?= $title ?>">
+        <a href="<?= $panel->getUrl() ?>" title="<?= $title ?>">
             <?= $panel->getSummaryName() ?>
-                <span class="yii-debug-toolbar__label
-                    <?= $hasError ? 'yii-debug-toolbar__label_error' : 'yii-debug-toolbar__label_info' ?>"
-                ><?= $queryCount ?></span> <span
-                class="yii-debug-toolbar__label"><?= $queryTime ?></span>
+            <span class="yii-debug-toolbar__label yii-debug-toolbar__label_info"><?= $queryCount ?></span>
+            <?php if ($warning): ?>
+                <span title="<?= $warning ?>">&#x26a0;</span>
+            <?php endif; ?>
+            <span class="yii-debug-toolbar__label"><?= $queryTime ?></span>
         </a>
     </div>
 <?php endif; ?>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #503 

With this PR exceeding the "critical query threshold" and/or "excessive callers" will no longer be displayed as an error in the debug panel. Only a "⚠" is displayed.

![image](https://github.com/yiisoft/yii2-debug/assets/1292337/ba0188c1-dcbc-485b-ad41-8b6e5f986f52)

