### PR TITLE
Correctly handle `null` values for `DbPanel::$criticalQueryThreshold` and `::$excessiveCallerThreshold`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 debug extension Change Log
 ------------------------
 
 - Bug #504: Reduced db panel warnings for "critical query threshold" and "excessive callers" (rhertogh)
+- Bug #506: Correctly handle null values for `DbPanel::$criticalQueryThreshold` and `::$excessiveCallerThreshold` (MarkoNV, rhertogh)
 
 
 2.1.23 May 22, 2023

--- a/docs/guide/db-panel.md
+++ b/docs/guide/db-panel.md
@@ -57,6 +57,7 @@ $config['modules']['debug'] = [
     'panels' => [
         'db' => [
             'class' => 'yii\debug\panels\DbPanel',
+            'criticalQueryThreshold' => 1000, // Show warning in case the total number of queries exceed this number.
             'excessiveCallerThreshold' => 10, // Increase the "Excessive Caller" threshold
             'ignoredPathsInBacktrace' => [
                 '@common/components/db/MyCustomDbCommand', // Ignore custom DB Command 
@@ -65,3 +66,6 @@ $config['modules']['debug'] = [
     ],
 ];
 ```
+
+> Note: Both `$criticalQueryThreshold` and `$excessiveCallerThreshold` can be disabled by setting their value to `null`.  
+> Changes in `$excessiveCallerThreshold` will only be reflected in new requests.

--- a/src/panels/DbPanel.php
+++ b/src/panels/DbPanel.php
@@ -29,13 +29,16 @@ use yii\log\Logger;
 class DbPanel extends Panel
 {
     /**
-     * @var int the threshold for determining whether the request has involved
+     * @var int|null the threshold for determining whether the request has involved
      * critical number of DB queries. If the number of queries exceeds this number,
      * the execution is considered taking critical number of DB queries.
+     * If it is `null`, this feature is disabled.
      */
     public $criticalQueryThreshold;
     /**
-     * @var int the number of DB calls the same backtrace can make before considered an "Excessive Caller".
+     * @var int|null the number of DB calls the same backtrace can make before considered an "Excessive Caller".
+     * If it is `null`, this feature is disabled.
+     * Note: Changes will only be reflected in new requests.
      * @since 2.1.23
      */
     public $excessiveCallerThreshold = 5;

--- a/src/panels/DbPanel.php
+++ b/src/panels/DbPanel.php
@@ -318,6 +318,10 @@ class DbPanel extends Panel
      */
     public function getExcessiveCallers()
     {
+        if ($this->excessiveCallerThreshold === null) {
+            return [];
+        }
+
         return array_filter(
             $this->countCallerCals(),
             function ($count) {
@@ -392,7 +396,7 @@ class DbPanel extends Panel
     }
 
     /**
-     * Check if given queries count is critical according settings.
+     * Check if given queries count is critical according to the settings.
      *
      * @param int $count queries count
      * @return bool
@@ -400,6 +404,17 @@ class DbPanel extends Panel
     public function isQueryCountCritical($count)
     {
         return (($this->criticalQueryThreshold !== null) && ($count > $this->criticalQueryThreshold));
+    }
+
+    /**
+     * Check if the number of calls by "Caller" is excessive according to the settings.
+     *
+     * @param int $numCalls queries count
+     * @return bool
+     */
+    public function isNumberOfCallsExcessive($numCalls)
+    {
+        return (($this->excessiveCallerThreshold !== null) && ($numCalls > $this->excessiveCallerThreshold));
     }
 
     /**

--- a/src/views/default/panels/db/callers.php
+++ b/src/views/default/panels/db/callers.php
@@ -54,7 +54,7 @@ echo GridView::widget([
             'attribute' => 'numCalls',
             'value' => function ($data) use ($panel) {
                 $result = $data['numCalls'];
-                if ($data['numCalls'] >= $panel->excessiveCallerThreshold) {
+                if ($panel->isNumberOfCallsExcessive($data['numCalls'])) {
                     $result .= ' ' . Html::tag('span', '&#x26a0;', [
                         'title' => 'Too many calls, number of calls should stay below ' . $panel->excessiveCallerThreshold,
                     ]);

--- a/src/views/default/panels/db/summary.php
+++ b/src/views/default/panels/db/summary.php
@@ -7,7 +7,7 @@
 $title = "Executed $queryCount database queries which took $queryTime.";
 $warning = '';
 
-if ($queryCount >= $panel->criticalQueryThreshold) {
+if ($panel->isQueryCountCritical($queryCount)) {
     $warning .= "Too many queries, allowed count is {$panel->criticalQueryThreshold}.";
 }
 if ($excessiveCallerCount) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #505
