### PR TITLE
Changed default value for `yii\debug\panels\DbPanel::$excessiveCaller…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 debug extension Change Log
 - Bug #504: Reduced db panel warnings for "critical query threshold" and "excessive callers" (rhertogh)
 - Bug #506: Correctly handle null values for `DbPanel::$criticalQueryThreshold` and `::$excessiveCallerThreshold` (MarkoNV, rhertogh)
 - Bug #507: Convert Symfony mailer headers to string in Mail panel (squio)
+- Enh #512: Changed default value for `yii\debug\panels\DbPanel::$excessiveCallerThreshold` to `null` (rhertogh)
 
 
 2.1.23 May 22, 2023

--- a/src/panels/DbPanel.php
+++ b/src/panels/DbPanel.php
@@ -41,7 +41,7 @@ class DbPanel extends Panel
      * Note: Changes will only be reflected in new requests.
      * @since 2.1.23
      */
-    public $excessiveCallerThreshold = 5;
+    public $excessiveCallerThreshold = null;
     /**
      * @var string[] the files and/or paths defined here will be ignored in the determination of DB "Callers".
      * The "Caller" is the backtrace lines that aren't included in the `$ignoredPathsInBacktrace`,


### PR DESCRIPTION
Changed default value for `yii\debug\panels\DbPanel::$excessiveCallerThreshold` to `null`

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #511
