### PR TITLE
Check if toolbar element is found on the page before access it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.1.25 under development
 ------------------------
 
-- no changes in this release.
+- Bug #503: Fix accessing toolbar data if it's not available (xepozz) 
 
 
 2.1.24 July 10, 2023

--- a/src/assets/js/toolbar.js
+++ b/src/assets/js/toolbar.js
@@ -320,6 +320,9 @@
      * @returns {boolean}
      */
     function shouldTrackRequest(requestUrl) {
+        if (!toolbarEl) {
+            return false;
+        }
         var a = document.createElement('a');
         a.href = requestUrl;
         var skipAjaxRequestUrls = JSON.parse(toolbarEl.getAttribute('data-skip-urls'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

When the toolbar scripts are loaded in case of bundled with other scripts, but the toolbar html is not present on the page any xhr / fetch calls fails on https://github.com/yiisoft/yii2-debug/blob/master/src/assets/js/toolbar.js#L325 with error `"Cannot read properties of null (reading 'getAttribute')"`
