### PR TITLE
If an internal PHP function, such as `call_user_func`, in the backtrace, the 'file' and 'line' not be available.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.1.26 under development
 ------------------------
 
-- no changes in this release.
+- Fix the backtrace, the 'file' and 'line' not be available (zymeli)
 
 
 2.1.25 September 26, 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.1.26 under development
 ------------------------
 
-- Fix the backtrace, the 'file' and 'line' not be available (zymeli)
+- Bug #528: Fix the backtrace, the 'file' and 'line' not be available (zymeli)
 
 
 2.1.25 September 26, 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.1.26 under development
 ------------------------
 
-- Bug #528: Fix the backtrace, the 'file' and 'line' not be available (zymeli)
+- Bug #528: Fix `yii\debug\Panel::getTraceLine()` to handle backtrace for internal PHP functions (zymeli)
 
 
 2.1.25 September 26, 2023

--- a/src/Panel.php
+++ b/src/Panel.php
@@ -131,6 +131,14 @@ class Panel extends Component
      */
     public function getTraceLine($options)
     {
+        /**
+         * If an internal PHP function, such as `call_user_func`, in the backtrace, the 'file' and 'line' not be available.
+         * @see https://www.php.net/manual/en/function.debug-backtrace.php#59713
+         */
+        if (!isset($options['file'])) {
+            return VarDumper::dumpAsString($options);
+        }
+
         if (!isset($options['text'])) {
             $options['text'] = "{$options['file']}:{$options['line']}";
         }

--- a/src/views/default/index.php
+++ b/src/views/default/index.php
@@ -17,7 +17,7 @@ $this->title = 'Yii Debugger';
     <div id="yii-debug-toolbar" class="yii-debug-toolbar yii-debug-toolbar_position_top" style="display: none;">
         <div class="yii-debug-toolbar__bar">
             <div class="yii-debug-toolbar__block yii-debug-toolbar__title">
-                <a href="#">
+                <a href="<?= Url::to(['index']) ?>">
                     <img width="30" height="30" alt="" src="<?= \yii\debug\Module::getYiiLogo() ?>">
                 </a>
             </div>

--- a/src/views/default/panels/log/detail.php
+++ b/src/views/default/panels/log/detail.php
@@ -136,7 +136,11 @@ echo GridView::widget([
                     $message .= Html::ul($data['trace'], [
                         'class' => 'trace',
                         'item' => static function ($trace) use ($panel) {
-                            return '<li>' . $panel->getTraceLine($trace) . '</li>';
+                            if (isset($trace['file'])) {
+                                return '<li>' . $panel->getTraceLine($trace) . '</li>';
+                            } else {
+                                return '<li>' . Html::encode(\yii\helpers\VarDumper::dumpAsString($trace)) . '</li>';
+                            }
                         }
                     ]);
                 }

--- a/src/views/default/panels/log/detail.php
+++ b/src/views/default/panels/log/detail.php
@@ -136,11 +136,7 @@ echo GridView::widget([
                     $message .= Html::ul($data['trace'], [
                         'class' => 'trace',
                         'item' => static function ($trace) use ($panel) {
-                            if (isset($trace['file'])) {
-                                return '<li>' . $panel->getTraceLine($trace) . '</li>';
-                            } else {
-                                return '<li>' . Html::encode(\yii\helpers\VarDumper::dumpAsString($trace)) . '</li>';
-                            }
+                            return '<li>' . $panel->getTraceLine($trace) . '</li>';
                         }
                     ]);
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️

It should be noted that if an internal php function such as call_user_func in the backtrace, the 'file' and 'line' entries will not be set.
@see  https://www.php.net/manual/en/function.debug-backtrace.php#59713
