### PR TITLE
Fix inconsistent switch case syntax

### DIFF
--- a/src/models/router/RouterRules.php
+++ b/src/models/router/RouterRules.php
@@ -95,7 +95,7 @@ class RouterRules extends Model
                     case WebUrlRule::CREATION_ONLY:
                         $mode = 'creation only';
                         break;
-                    case null;
+                    case null:
                         $mode = null;
                         break;
                     default:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

I assume this was a typo, since it's the only case statement using the non-standard syntax.