### PR TITLE
Fixed backticks used instead of single quotes.

### DIFF
--- a/src/panels/UserPanel.php
+++ b/src/panels/UserPanel.php
@@ -237,7 +237,7 @@ class UserPanel extends Panel
 
         try {
             
-            $authManager = Instance::ensure($this->module->authManager, `\yii\rbac\BaseManager`);
+            $authManager = Instance::ensure($this->module->authManager, '\yii\rbac\BaseManager');
 
             if ($authManager instanceof \yii\rbac\ManagerInterface) {
                 $roles = ArrayHelper::toArray($authManager->getRolesByUser($this->getUser()->id));


### PR DESCRIPTION
This fixes an issue where backticks cause a shell command to be executed instead of creating a string with a FQCN.

The backticks are replaced by quotes.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  |  None
