### PR TITLE
Silence fetch errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 debug extension Change Log
 2.1.28 under development
 ------------------------
 
-- no changes in this release.
+- Bug #541: Silence fetch errors (Karkbauer)
 
 
 2.1.27 June 08, 2025

--- a/src/assets/js/toolbar.js
+++ b/src/assets/js/toolbar.js
@@ -404,8 +404,6 @@
                     stackElement.loading = false;
                     stackElement.error = true;
                     renderAjaxRequests();
-
-                    throw error;
                 });
                 renderAjaxRequests();
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 

In cases when `fetch(...)` results in an error (for example, a network issue or the request is aborted), allow the call site to choose whether to ignore the error, or handle it. As the the toolbar has a separate promise chain, that the call site has no access to, rethrowing the error causes unnecessary noise in console logs when the error has already been handled by the call site.

This separate promise chain is not used after updating the `stackElement` array, so its safe to not rethrown error.

**Before:**
* Unhandled errors log _two_ messages in console 
* Handled errors log _one_ message in console

**After:**
* Unhandled errors log _one_ message in console 
* Handled errors log _none_ messages in console

An example where no error message is expected to be logged now:

```js
const controller = new AbortController();
fetch('/my/path', {signal: controller.signal})
  .catch(e => {
    if (e.name !== 'AbortError') {
      throw e;
    }
  });
controller.abort();
```
