### PR TITLE
Fix Deprecated `ArrayObject::__construct()` and Method `ReflectionMethod::setAccessible()` in PHP `8.5`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 debug extension Change Log
 - Bug #541: Silence fetch errors (Karkbauer)
 - Enh #546: Applying Yii2 coding standards (@s1lver)
 - Enh #546: Raise min version to PHP 7.4 (@s1lver)
+- Bug #548: Fix Deprecated ArrayObject::__construct() and Method ReflectionMethod::setAccessible() in PHP 8.5 (@terabytesoftw)
 
 
 2.1.27 June 08, 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Yii Framework 2 debug extension Change Log
 - Bug #541: Silence fetch errors (Karkbauer)
 - Enh #546: Applying Yii2 coding standards (@s1lver)
 - Enh #546: Raise min version to PHP 7.4 (@s1lver)
-- Bug #548: Fix Deprecated ArrayObject::__construct() and Method ReflectionMethod::setAccessible() in PHP 8.5 (@terabytesoftw)
+- Bug #548: Fix `Deprecated ArrayObject::__construct()` and Method `ReflectionMethod::setAccessible()` in PHP 8.5 (@terabytesoftw)
 
 
 2.1.27 June 08, 2025

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -265,12 +265,6 @@ parameters:
 			path: src/Module.php
 
 		-
-			message: '#^Method yii\\debug\\Module\:\:checkAccess\(\) has parameter \$action with generic class yii\\base\\Action but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Module.php
-
-		-
 			message: '#^Method yii\\debug\\Module\:\:corePanels\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -463,12 +457,6 @@ parameters:
 			path: src/actions/db/ExplainAction.php
 
 		-
-			message: '#^Class yii\\debug\\actions\\db\\ExplainAction extends generic class yii\\base\\Action but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/actions/db/ExplainAction.php
-
-		-
 			message: '#^Method yii\\debug\\components\\search\\Filter\:\:addMatcher\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -553,12 +541,6 @@ parameters:
 			path: src/controllers/DefaultController.php
 
 		-
-			message: '#^Class yii\\debug\\controllers\\DefaultController extends generic class yii\\web\\Controller but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/controllers/DefaultController.php
-
-		-
 			message: '#^Method yii\\debug\\controllers\\DefaultController\:\:getManifest\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -625,24 +607,6 @@ parameters:
 			path: src/controllers/UserController.php
 
 		-
-			message: '#^Class yii\\debug\\controllers\\UserController extends generic class yii\\web\\Controller but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/controllers/UserController.php
-
-		-
-			message: '#^Method yii\\debug\\controllers\\UserController\:\:actionResetIdentity\(\) return type with generic class yii\\web\\User does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/controllers/UserController.php
-
-		-
-			message: '#^Method yii\\debug\\controllers\\UserController\:\:actionSetIdentity\(\) return type with generic class yii\\web\\User does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/controllers/UserController.php
-
-		-
 			message: '#^Parameter \#1 \$identity of method yii\\debug\\models\\UserSwitch\:\:setUserByIdentity\(\) expects yii\\web\\IdentityInterface, yii\\web\\IdentityInterface\|null given\.$#'
 			identifier: argument.type
 			count: 1
@@ -697,18 +661,6 @@ parameters:
 			path: src/models/UserSwitch.php
 
 		-
-			message: '#^Method yii\\debug\\models\\UserSwitch\:\:getMainUser\(\) return type with generic class yii\\web\\User does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/models/UserSwitch.php
-
-		-
-			message: '#^Method yii\\debug\\models\\UserSwitch\:\:getUser\(\) return type with generic class yii\\web\\User does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/models/UserSwitch.php
-
-		-
 			message: '#^Method yii\\debug\\models\\UserSwitch\:\:getUser\(\) should return yii\\web\\User\|null but returns object\|null\.$#'
 			identifier: return.type
 			count: 1
@@ -727,38 +679,14 @@ parameters:
 			path: src/models/UserSwitch.php
 
 		-
-			message: '#^Method yii\\debug\\models\\UserSwitch\:\:setUser\(\) has parameter \$user with generic class yii\\web\\User but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/models/UserSwitch.php
-
-		-
 			message: '#^Method yii\\debug\\models\\UserSwitch\:\:setUserByIdentity\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/models/UserSwitch.php
 
 		-
-			message: '#^Property yii\\debug\\models\\UserSwitch\:\:\$_mainUser with generic class yii\\web\\User does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/models/UserSwitch.php
-
-		-
 			message: '#^Property yii\\debug\\models\\UserSwitch\:\:\$_user \(yii\\web\\User\) does not accept object\|null\.$#'
 			identifier: assign.propertyType
-			count: 1
-			path: src/models/UserSwitch.php
-
-		-
-			message: '#^Property yii\\debug\\models\\UserSwitch\:\:\$_user with generic class yii\\web\\User does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/models/UserSwitch.php
-
-		-
-			message: '#^Property yii\\debug\\models\\UserSwitch\:\:\$userComponent with generic class yii\\web\\User does not specify its types\: T$#'
-			identifier: missingType.generics
 			count: 1
 			path: src/models/UserSwitch.php
 
@@ -1963,12 +1891,6 @@ parameters:
 			path: src/panels/UserPanel.php
 
 		-
-			message: '#^Method yii\\debug\\panels\\UserPanel\:\:getUser\(\) return type with generic class yii\\web\\User does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/panels/UserPanel.php
-
-		-
 			message: '#^Method yii\\debug\\panels\\UserPanel\:\:getUser\(\) should return yii\\web\\User\|null but returns object\|null\.$#'
 			identifier: return.type
 			count: 1
@@ -1987,19 +1909,13 @@ parameters:
 			path: src/panels/UserPanel.php
 
 		-
-			message: '#^PHPDoc tag @var for variable \$userController contains generic class yii\\base\\Controller but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/panels/UserPanel.php
-
-		-
 			message: '#^PHPDoc tag @var with type yii\\base\\Controller is not subtype of native type null\.$#'
 			identifier: varTag.nativeType
 			count: 1
 			path: src/panels/UserPanel.php
 
 		-
-			message: '#^Parameter \#1 \$action of method yii\\filters\\AccessRule\:\:allows\(\) expects yii\\base\\Action\<yii\\base\\Controller\<yii\\base\\Module\>\>, yii\\base\\Action\<yii\\base\\Controller\>\|null given\.$#'
+			message: '#^Parameter \#1 \$action of method yii\\filters\\AccessRule\:\:allows\(\) expects yii\\base\\Action, yii\\base\\Action\<yii\\base\\Controller\>\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/panels/UserPanel.php
@@ -2037,12 +1953,6 @@ parameters:
 		-
 			message: '#^Property yii\\debug\\panels\\UserPanel\:\:\$ruleUserSwitch type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/panels/UserPanel.php
-
-		-
-			message: '#^Property yii\\debug\\panels\\UserPanel\:\:\$userComponent with generic class yii\\web\\User does not specify its types\: T$#'
-			identifier: missingType.generics
 			count: 1
 			path: src/panels/UserPanel.php
 
@@ -2131,7 +2041,7 @@ parameters:
 			path: src/views/default/panels/db/callers.php
 
 		-
-			message: '#^Cannot access property \$summary on yii\\console\\Controller\<yii\\base\\Module\>\|yii\\web\\Controller\<yii\\base\\Module\>\|null\.$#'
+			message: '#^Cannot access property \$summary on yii\\console\\Controller\|yii\\web\\Controller\|null\.$#'
 			identifier: property.nonObject
 			count: 1
 			path: src/views/default/panels/db/callers.php
@@ -2203,7 +2113,7 @@ parameters:
 			path: src/views/default/panels/db/detail.php
 
 		-
-			message: '#^Cannot access property \$summary on yii\\console\\Controller\<yii\\base\\Module\>\|yii\\web\\Controller\<yii\\base\\Module\>\|null\.$#'
+			message: '#^Cannot access property \$summary on yii\\console\\Controller\|yii\\web\\Controller\|null\.$#'
 			identifier: property.nonObject
 			count: 1
 			path: src/views/default/panels/db/queries.php
@@ -2665,7 +2575,7 @@ parameters:
 			path: src/views/layouts/main.php
 
 		-
-			message: '#^Cannot access property \$module on yii\\console\\Controller\<yii\\base\\Module\>\|yii\\web\\Controller\<yii\\base\\Module\>\|null\.$#'
+			message: '#^Cannot access property \$module on yii\\console\\Controller\|yii\\web\\Controller\|null\.$#'
 			identifier: property.nonObject
 			count: 1
 			path: src/views/layouts/main.php
@@ -2863,12 +2773,6 @@ parameters:
 			path: tests/router/RouterRulesTest.php
 
 		-
-			message: '#^Class yiiunit\\debug\\router\\controllers\\BadController extends generic class yii\\web\\Controller but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: tests/router/controllers/BadController.php
-
-		-
 			message: '#^Method yiiunit\\debug\\router\\controllers\\BadController\:\:actionOnly\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -2893,12 +2797,6 @@ parameters:
 			path: tests/router/controllers/RedirectController.php
 
 		-
-			message: '#^Class yiiunit\\debug\\router\\controllers\\RedirectController extends generic class yii\\web\\Controller but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: tests/router/controllers/RedirectController.php
-
-		-
 			message: '#^Method yiiunit\\debug\\router\\controllers\\RedirectController\:\:actionOnly\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -2909,18 +2807,6 @@ parameters:
 			identifier: missingType.return
 			count: 1
 			path: tests/router/controllers/RedirectController.php
-
-		-
-			message: '#^Class yiiunit\\debug\\router\\controllers\\RestController extends generic class yii\\rest\\ActiveController but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: tests/router/controllers/RestController.php
-
-		-
-			message: '#^Class yiiunit\\debug\\router\\controllers\\WebController extends generic class yii\\web\\Controller but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: tests/router/controllers/WebController.php
 
 		-
 			message: '#^Method yiiunit\\debug\\router\\controllers\\WebController\:\:actionFirst\(\) has no return type specified\.$#'
@@ -2939,12 +2825,6 @@ parameters:
 			identifier: missingType.return
 			count: 1
 			path: tests/router/controllers/WebController.php
-
-		-
-			message: '#^Class yiiunit\\debug\\router\\module\\controllers\\ModuleWebController extends generic class yii\\web\\Controller but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: tests/router/module/controllers/ModuleWebController.php
 
 		-
 			message: '#^Method yiiunit\\debug\\router\\module\\controllers\\ModuleWebController\:\:actionInside\(\) has no return type specified\.$#'

--- a/src/FlattenException.php
+++ b/src/FlattenException.php
@@ -292,7 +292,7 @@ class FlattenException
      */
     private function getClassNameFromIncomplete(\__PHP_Incomplete_Class $value)
     {
-        $array = new \ArrayObject($value);
+        $array = new \ArrayObject(\get_object_vars($value));
 
         return $array['__PHP_Incomplete_Class_Name'];
     }

--- a/src/FlattenException.php
+++ b/src/FlattenException.php
@@ -292,8 +292,8 @@ class FlattenException
      */
     private function getClassNameFromIncomplete(\__PHP_Incomplete_Class $value)
     {
-        $array = new \ArrayObject(\get_object_vars($value));
+        $array = \get_object_vars($value);
 
-        return $array['__PHP_Incomplete_Class_Name'];
+        return (string) ($array['__PHP_Incomplete_Class_Name'] ?? '');
     }
 }

--- a/src/models/router/RouterRules.php
+++ b/src/models/router/RouterRules.php
@@ -144,7 +144,7 @@ class RouterRules extends Model
         $reflectionClass = new \ReflectionClass($restRule);
         $reflectionProperty = $reflectionClass->getProperty('rules');
 
-        if (PHP_VERSION_ID < 80500) {
+        if (PHP_VERSION_ID < 80100) {
             $reflectionProperty->setAccessible(true);
         }
 

--- a/src/models/router/RouterRules.php
+++ b/src/models/router/RouterRules.php
@@ -143,7 +143,11 @@ class RouterRules extends Model
     {
         $reflectionClass = new \ReflectionClass($restRule);
         $reflectionProperty = $reflectionClass->getProperty('rules');
-        $reflectionProperty->setAccessible(true);
+
+        if (PHP_VERSION_ID < 80500) {
+            $reflectionProperty->setAccessible(true);
+        }
+
         $rulesGroups = $reflectionProperty->getValue($restRule);
 
         foreach ($rulesGroups as $rules) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -74,13 +74,13 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $classReflection = new \ReflectionClass(get_class($object));
         $methodReflection = $classReflection->getMethod($method);
 
-        if (PHP_VERSION_ID < 80500) {
+        if (PHP_VERSION_ID < 80100) {
             $methodReflection->setAccessible(true);
         }
 
         $result = $methodReflection->invokeArgs($object, $args);
 
-        if (PHP_VERSION_ID < 80500) {
+        if (PHP_VERSION_ID < 80100) {
             $methodReflection->setAccessible(false);
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -73,9 +73,17 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     {
         $classReflection = new \ReflectionClass(get_class($object));
         $methodReflection = $classReflection->getMethod($method);
-        $methodReflection->setAccessible(true);
+
+        if (PHP_VERSION_ID < 80500) {
+            $methodReflection->setAccessible(true);
+        }
+
         $result = $methodReflection->invokeArgs($object, $args);
-        $methodReflection->setAccessible(false);
+
+        if (PHP_VERSION_ID < 80500) {
+            $methodReflection->setAccessible(false);
+        }
+
         return $result;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌
